### PR TITLE
configure dev server port

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,17 +2,23 @@ import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
-// https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, "..", "");
-  const proxyTarget =
-    env.BACKEND_PROXY_TARGET || env.VITE_BACKEND_URL || "http://localhost:8080";
+  const proxyTarget = env.BACKEND_PROXY_TARGET 
+    || env.VITE_BACKEND_URL 
+    || "http://localhost:8080";
 
   return {
     envDir: "..",
     plugins: [tailwindcss(), react()],
     server: {
-      host: true,
+      host: true, 
+      port: 5173,
+      strictPort: true,
+      allowedHosts: [
+        'identity-provider.isaxbsit2027.com'
+      ],
+
       proxy: {
         "/api/v1": {
           target: proxyTarget,


### PR DESCRIPTION
This pull request updates the Vite configuration for the frontend to improve development server setup and security. The most important changes are listed below.

**Development server configuration:**

* Set the development server to use port `5173` and enabled `strictPort` to ensure the server fails if the port is unavailable.

**Security and allowed hosts:**

* Restricted allowed hosts to only `identity-provider.isaxbsit2027.com` for improved security during development.

**Code style and readability:**

* Reformatted the `proxyTarget` assignment for better readability.