### PR TITLE
add error handling in creating client

### DIFF
--- a/backend/internal/initializers/storage.go
+++ b/backend/internal/initializers/storage.go
@@ -31,7 +31,11 @@ func NewS3Storage() error {
 	if publicEndpoint == "" {
 		signedEndpoint = endpoint
 	}
+	
 	client, err := createClient(signedEndpoint, accessKey, secretKey, useSSL)
+	if err != nil {
+		return fmt.Errorf("[StorageInit] Client Creation: %v", err)
+	}
 
 	// 4. Assign to global variable
 	Storage = &storage.S3Provider{


### PR DESCRIPTION
This pull request adds error handling to the S3 storage initialization logic. Now, if the S3 client fails to be created, an error is returned with a helpful message instead of proceeding with an invalid client. 

* Improved error handling:
  * [`backend/internal/initializers/storage.go`](diffhunk://#diff-683f9115c2a7d121a4b380d7c41bb842681f11a12e26188f7b8c62494ea77726R34-R38): Added a check for errors when creating the S3 client in `NewS3Storage`, returning a formatted error if client creation fails.