### PR TITLE
Fix/seed

### DIFF
--- a/backend/internal/initializers/seed.go
+++ b/backend/internal/initializers/seed.go
@@ -187,7 +187,7 @@ func seedAppClient(adminDatabase *sqlx.DB) error {
 		RedirectUri:   cCallback,
 		LogoutUri:     cBase,
 		Description:   "Identity Provider",
-		ImageLocation: "",
+		ImageLocation: "idp.png",
 	}
 
 	adminEmail := os.Getenv("ADMIN_EMAIL")

--- a/backend/internal/initializers/seed.go
+++ b/backend/internal/initializers/seed.go
@@ -71,7 +71,7 @@ func seedSuperAdminRole(db *sqlx.DB) (int, error) {
 	roleRepo := repository.NewRoleRepository(db)
 	permissionRepo := repository.NewPermissionRepository(db)
 
-	roleName := "IDP:superadmin"
+	roleName := "Superadmin"
 	var existingID int
 	query := "SELECT id FROM roles WHERE role_name = ? AND deleted_at IS NULL"
 	err := db.Get(&existingID, query, roleName)


### PR DESCRIPTION
This pull request makes minor improvements to the seed data for roles and application clients. The most important changes are:

Seed data adjustments:

* Changed the default superadmin role name from `"IDP:superadmin"` to `"Superadmin"` in the `seedSuperAdminRole` function to standardize role naming.
* Set the `ImageLocation` for the seeded app client to `"idp.png"` instead of an empty string, ensuring the client has an associated image.