### PR TITLE
add guardrail to empty appclient

### DIFF
--- a/backend/internal/api/v1/client_handler.go
+++ b/backend/internal/api/v1/client_handler.go
@@ -183,8 +183,13 @@ func (h *ClientHandler) GetClientList(c *gin.Context) {
 		})
 		return
 	}
-
-	c.JSON(http.StatusOK, resp)
+	if resp == nil {
+		log.Printf("[GetClientList] %v", err)
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error: "null clients",
+		})
+		return
+	}
 
 	c.JSON(http.StatusOK, resp)
 }


### PR DESCRIPTION
This pull request improves error handling in the `GetClientList` API endpoint by adding a check for a `nil` response and returning an appropriate error message if no clients are found.

Error handling improvements:

* Added a check for a `nil` `resp` in the `GetClientList` handler, returning a 500 error with a "null clients" message and logging the error if the client list is empty.