### PR TITLE
Fix/client list

### DIFF
--- a/backend/internal/api/v1/client_handler.go
+++ b/backend/internal/api/v1/client_handler.go
@@ -183,8 +183,13 @@ func (h *ClientHandler) GetClientList(c *gin.Context) {
 		})
 		return
 	}
-
-	c.JSON(http.StatusOK, resp)
+	if resp == nil {
+		log.Printf("[GetClientList] %v", err)
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Error: "null clients",
+		})
+		return
+	}
 
 	c.JSON(http.StatusOK, resp)
 }

--- a/backend/internal/service/media.go
+++ b/backend/internal/service/media.go
@@ -21,6 +21,10 @@ func ProcessAndUploadIcon(
 	size int64,
 	storage *storage.S3Provider,
 ) (string, error) {
+	if storage == nil {
+		return "", fmt.Errorf("[MediaService] Storage provider is not initialized")
+	}
+
 	// 1. Validate Header
 	header := make([]byte, 512)
 	if _, err := fileReader.Read(header); err != nil {
@@ -61,11 +65,24 @@ func ProcessAndUploadIcon(
 func GetPresignedURL(ctx context.Context,
 	object string, storage *storage.S3Provider,
 ) (string, error) {
+	if storage == nil || storage.Client == nil {
+		return "", fmt.Errorf("[MediaService] Storage provider is not initialized")
+	}
+	if object == "" {
+		return "", nil
+	}
+
 	// Clean path for S3 standards
 	object = strings.TrimPrefix(object, "/")
 	expiry := time.Second * 3600
 
-	isMinio := strings.Contains(storage.Client.EndpointURL().Host, "minio")
+	isMinio := false
+	var internalHost string
+	endpointURL := storage.Client.EndpointURL()
+	if endpointURL != nil {
+		internalHost = endpointURL.Host
+		isMinio = strings.Contains(internalHost, "minio")
+	}
     
     if isMinio {
         publicURL := fmt.Sprintf("http://%s/%s/%s", 
@@ -87,11 +104,12 @@ func GetPresignedURL(ctx context.Context,
 	}
 
 	urlStr := presignedURL.String()
-	internalHost := storage.Client.EndpointURL().Host
 
-	if storage.PublicEndpoint != "" && storage.PublicEndpoint != internalHost {
-		urlStr = strings.Replace(urlStr, internalHost,
-			storage.PublicEndpoint, 1)
+	if endpointURL != nil {
+		if storage.PublicEndpoint != "" && storage.PublicEndpoint != internalHost {
+			urlStr = strings.Replace(urlStr, internalHost,
+				storage.PublicEndpoint, 1)
+		}
 	}
 
 	return urlStr, nil
@@ -100,6 +118,10 @@ func GetPresignedURL(ctx context.Context,
 func DeleteImage(ctx context.Context, object string,
 	storage *storage.S3Provider,
 ) error {
+	if storage == nil || storage.Client == nil {
+		return fmt.Errorf("[DeleteImage] Storage provider is not initialized")
+	}
+
 	// RemoveObject options can be used for versioning or governance bypass
 	opts := minio.RemoveObjectOptions{}
 


### PR DESCRIPTION
This pull request introduces several improvements to error handling and robustness in the backend service, particularly around S3 storage operations and client list retrieval. The changes ensure that the application gracefully handles cases where dependencies (like the storage provider) are not properly initialized, and provides clearer error responses to clients.

**Error handling and robustness improvements:**

* Added a check in `ProcessAndUploadIcon` to return an error if the `storage` provider is not initialized, preventing potential nil pointer dereferences.
* Enhanced `GetPresignedURL` to return an error if the `storage` provider or its client is not initialized, and to handle empty object names gracefully.
* Improved `DeleteImage` by adding a nil check for the `storage` provider and its client, returning a clear error if uninitialized.

**Client API improvements:**

* Updated `GetClientList` to return an internal server error response if the list of clients is unexpectedly `nil`, providing better feedback for error scenarios.

**S3 endpoint handling:**

* Refactored `GetPresignedURL` to safely handle cases where the endpoint URL might be nil, and to correctly determine if the storage is MinIO-based. [[1]](diffhunk://#diff-15169816ae1494c530c5385003ad899531b4731e40e3e004ec33121fb6f7d817R68-R85) [[2]](diffhunk://#diff-15169816ae1494c530c5385003ad899531b4731e40e3e004ec33121fb6f7d817L90-R124)