### PR TITLE
Update auth service with grant type logic and validation

### DIFF
--- a/backend/internal/api/v1/auth_handler.go
+++ b/backend/internal/api/v1/auth_handler.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -154,6 +155,23 @@ func (h *AuthHandler) LoginAndAuthorize(c *gin.Context) {
 		log.Printf("[LoginAndAuthorize] Bind JSON: %v", err)
 		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
 			Error: "Invalid request format",
+		})
+		return
+	}
+
+	// Verify client grant type
+	cID, err := uuid.Parse(req.ClientID)
+	if err != nil {
+		log.Printf("[LoginAndAuthorize] UUID Parse: %v", err)
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error: "invalid client_id format",
+		})
+		return
+	}
+	client, err := h.ClientService.GetClientByID(c.Request.Context(), cID)
+	if err != nil || !slices.Contains(client.Grants, "authorization_code") {
+		c.JSON(http.StatusForbidden, dto.ErrorResponse{
+			Error: "missing grant type",
 		})
 		return
 	}
@@ -496,6 +514,23 @@ func (h *AuthHandler) PostTokenExchange(c *gin.Context) {
 		return
 	}
 
+	// Verify client grant type
+	cID, err := uuid.Parse(req.ClientID)
+	if err != nil {
+		log.Printf("[PostTokenExchange] UUID Parse: %v", err)
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error: "invalid client_id format",
+		})
+		return
+	}
+	client, err := h.ClientService.GetClientByID(c.Request.Context(), cID)
+	if err != nil || !slices.Contains(client.Grants, "client_credentials") {
+		c.JSON(http.StatusForbidden, dto.ErrorResponse{
+			Error: "missing grant type",
+		})
+		return
+	}
+
 	// Resolve client name
 	clientName := h.LogService.ResolveClientName(
 		c.Request.Context(),
@@ -632,6 +667,8 @@ func (h *AuthHandler) PostTokenRotate(c *gin.Context) {
 
 		if strings.Contains(err.Error(), "TokenLookup") {
 			status, errorMsg = http.StatusUnauthorized, "invalid_token"
+		} else if strings.Contains(err.Error(), "missing refresh_token grant") {
+			status, errorMsg = http.StatusForbidden, "missing grant type"
 		} else if strings.Contains(err.Error(), "RotateToken") {
 			status, errorMsg = http.StatusInternalServerError, "rotate_fail"
 		}

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"fmt"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/Iskolutions-Capstone-Dev-Team/Identity-Provider/internal/dto"
@@ -251,15 +252,19 @@ func (s *authService) ExchangeCodeForToken(
 		return nil, fmt.Errorf("Token Generation: %w", err)
 	}
 
-	refreshStr, _ := utils.GenerateRandomString(SECRET_ENTROPY)
-	err = s.Repo.StoreRefreshToken(
-		ctx,
-		refreshStr,
-		authCode.UserId,
-		clientIDBin,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("Database Query (StoreRefresh): %w", err)
+	grants, _ := s.ClientRepo.GetGrantTypes(ctx, clientIDBin)
+	var refreshStr string
+	if slices.Contains(grants, "refresh_token") {
+		refreshStr, _ = utils.GenerateRandomString(SECRET_ENTROPY)
+		err = s.Repo.StoreRefreshToken(
+			ctx,
+			refreshStr,
+			authCode.UserId,
+			clientIDBin,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("Database Query (StoreRefresh): %w", err)
+		}
 	}
 
 	return &dto.TokenResponse{
@@ -281,6 +286,12 @@ func (s *authService) RotateRefreshToken(
 	uID, cID, err := s.Repo.GetIDsFromToken(ctx, oldToken)
 	if err != nil {
 		return nil, fmt.Errorf("Database Query (TokenLookup): %w", err)
+	}
+
+	// 1.1 Verify Client Grant Type
+	grants, _ := s.ClientRepo.GetGrantTypes(ctx, cID)
+	if !slices.Contains(grants, "refresh_token") {
+		return nil, fmt.Errorf("Client Verification: missing refresh_token grant")
 	}
 
 	// 2. Generate and persist new Refresh Token


### PR DESCRIPTION
This pull request strengthens OAuth2 grant type enforcement in both the API and service layers, ensuring that clients can only perform actions for which they have explicit grants. The main changes include grant type checks for authorization, token exchange, and refresh token rotation, as well as improvements to error handling and refresh token issuance.

**Grant type enforcement in API handlers:**
- Added checks in `LoginAndAuthorize` to ensure the client has the `authorization_code` grant before proceeding.
- Added checks in `PostTokenExchange` to ensure the client has the `client_credentials` grant before allowing token exchange.
- Improved error handling in `PostTokenRotate` to return a specific error when the `refresh_token` grant is missing.

**Service layer improvements:**
- In `ExchangeCodeForToken`, only issues a refresh token if the client has the `refresh_token` grant. [[1]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaL254-R258) [[2]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaR268)
- In `RotateRefreshToken`, verifies that the client has the `refresh_token` grant before rotating the token, returning a clear error if not.

**Code maintenance:**
- Added the `slices` package import where needed to support slice operations. [[1]](diffhunk://#diff-a56cf3acfe5a0ba8b75618214b0cba319502fadc836943545b7bc63e390399feR7) [[2]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaR9)