### PR TITLE
remove JS-accessible refresh token storage

### DIFF
--- a/frontend/src/auth/components/ProtectedRoute.jsx
+++ b/frontend/src/auth/components/ProtectedRoute.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { clearAuthState } from "../utils/authCookies";
+import { rememberAuthorizeReturnPath } from "../utils/authorizeFlow";
 import { buildLoginPath, buildUnauthorizedLoginPath } from "../utils/loginRoute";
 import { userService } from "../../services/userService";
 import { hasAssignedRoles } from "../utils/authAccess";
@@ -8,12 +9,16 @@ import { hasStoredAuthTokens } from "../utils/authRecovery";
 
 export default function ProtectedRoute({ children }) {
   const [authState, setAuthState] = useState("loading");
+  const location = useLocation();
 
   useEffect(() => {
     let isActive = true;
+    const returnPath =
+      `${location.pathname}${location.search}${location.hash}` || "/";
 
     const validate = async () => {
       if (!hasStoredAuthTokens()) {
+        rememberAuthorizeReturnPath(returnPath);
         setAuthState("redirect-to-sso");
         return;
       }
@@ -44,6 +49,13 @@ export default function ProtectedRoute({ children }) {
         }
 
         clearAuthState();
+        rememberAuthorizeReturnPath(returnPath);
+
+        if (error.response?.status === 401) {
+          setAuthState("redirect-to-sso");
+          return;
+        }
+
         setAuthState("denied");
       }
     };
@@ -53,7 +65,7 @@ export default function ProtectedRoute({ children }) {
     return () => {
       isActive = false;
     };
-  }, []);
+  }, [location.hash, location.pathname, location.search]);
 
   if (authState === "loading") {
     return (

--- a/frontend/src/auth/pages/AuthorizeRedirect.jsx
+++ b/frontend/src/auth/pages/AuthorizeRedirect.jsx
@@ -1,9 +1,8 @@
 import { useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { buildLoginPath } from "../utils/loginRoute";
-import { DEFAULT_AUTHENTICATED_PATH } from "../utils/authAccess";
 import { hasStoredAccessToken } from "../utils/authRecovery";
-import { redirectToAuthorize } from "../utils/authorizeFlow";
+import { getAuthorizeReturnPath, redirectToAuthorize } from "../utils/authorizeFlow";
 
 const authClientId = import.meta.env.VITE_CLIENT_ID ?? "";
 
@@ -16,14 +15,16 @@ export default function AuthorizeRedirect() {
     hasRun.current = true;
 
     const redirectToNextPage = () => {
+      const returnPath = getAuthorizeReturnPath();
+
       if (hasStoredAccessToken()) {
-        navigate(DEFAULT_AUTHENTICATED_PATH, { replace: true });
+        navigate(returnPath, { replace: true });
         return;
       }
 
       const didRedirect = redirectToAuthorize(
         authClientId,
-        DEFAULT_AUTHENTICATED_PATH,
+        returnPath,
       );
 
       if (didRedirect) {

--- a/frontend/src/auth/pages/Callback.jsx
+++ b/frontend/src/auth/pages/Callback.jsx
@@ -26,8 +26,8 @@ export default function Callback() {
       try {
         const tokenResponse = await authService.exchangeCode(code);
 
-        if (!tokenResponse?.access_token || !tokenResponse?.refresh_token) {
-          throw new Error("Token exchange did not return both tokens.");
+        if (!tokenResponse?.access_token) {
+          throw new Error("Token exchange did not return an access token.");
         }
 
         storeTokenResponse(tokenResponse);

--- a/frontend/src/auth/utils/authCookies.js
+++ b/frontend/src/auth/utils/authCookies.js
@@ -1,19 +1,24 @@
 import { clearAuthorizeReturnPath } from "./authorizeFlow";
 
 const ACCESS_TOKEN_COOKIE = "access_token";
-const REFRESH_TOKEN_COOKIE = "refresh_token";
+const LEGACY_REFRESH_TOKEN_COOKIE = "refresh_token";
 const TERMS_STORAGE_KEY = "termsAccepted";
 const DEFAULT_ACCESS_TOKEN_MAX_AGE_SECONDS = 3600;
-const REFRESH_TOKEN_MAX_AGE_SECONDS = 7 * 24 * 60 * 60;
 
-function getCookieValue(name) {
+function getCookieRow(name) {
   if (typeof document === "undefined") {
     return "";
   }
 
-  const cookie = document.cookie
-    .split("; ")
-    .find((row) => row.startsWith(`${name}=`));
+  return (
+    document.cookie
+      .split("; ")
+      .find((row) => row.startsWith(`${name}=`)) ?? ""
+  );
+}
+
+function getCookieValue(name) {
+  const cookie = getCookieRow(name);
 
   if (!cookie) {
     return "";
@@ -54,12 +59,12 @@ export function getAccessToken() {
   return getCookieValue(ACCESS_TOKEN_COOKIE);
 }
 
-export function getRefreshToken() {
-  return getCookieValue(REFRESH_TOKEN_COOKIE);
-}
+export function clearLegacyRefreshTokenCookie() {
+  if (!getCookieRow(LEGACY_REFRESH_TOKEN_COOKIE)) {
+    return;
+  }
 
-export function hasRefreshToken() {
-  return Boolean(getRefreshToken());
+  expireCookie(LEGACY_REFRESH_TOKEN_COOKIE);
 }
 
 export function storeTokenResponse(tokenResponse) {
@@ -68,7 +73,6 @@ export function storeTokenResponse(tokenResponse) {
   }
 
   const accessToken = tokenResponse.access_token;
-  const refreshToken = tokenResponse.refresh_token;
   const expiresIn =
     Number(tokenResponse.expires_in) || DEFAULT_ACCESS_TOKEN_MAX_AGE_SECONDS;
 
@@ -80,18 +84,13 @@ export function storeTokenResponse(tokenResponse) {
     );
   }
 
-  if (refreshToken) {
-    document.cookie = buildCookie(
-      REFRESH_TOKEN_COOKIE,
-      refreshToken,
-      REFRESH_TOKEN_MAX_AGE_SECONDS,
-    );
-  }
+  // Refresh tokens must stay server-managed, not in JS-readable storage.
+  clearLegacyRefreshTokenCookie();
 }
 
 export function clearAuthState() {
   expireCookie(ACCESS_TOKEN_COOKIE);
-  expireCookie(REFRESH_TOKEN_COOKIE);
+  clearLegacyRefreshTokenCookie();
   expireCookie("token");
   clearAuthorizeReturnPath();
 

--- a/frontend/src/auth/utils/authRecovery.js
+++ b/frontend/src/auth/utils/authRecovery.js
@@ -1,9 +1,9 @@
-import { getAccessToken, hasRefreshToken } from "./authCookies";
+import { getAccessToken } from "./authCookies";
 
 export function hasStoredAccessToken() {
   return Boolean(getAccessToken());
 }
 
 export function hasStoredAuthTokens() {
-  return hasStoredAccessToken() || hasRefreshToken();
+  return hasStoredAccessToken();
 }

--- a/frontend/src/auth/utils/tokenRefresh.js
+++ b/frontend/src/auth/utils/tokenRefresh.js
@@ -1,20 +1,6 @@
-import axios from "axios";
-import { clearAuthState, getAccessToken, getRefreshToken, hasRefreshToken, storeTokenResponse } from "./authCookies";
-import {
-  isIdpProtectedPath,
-  redirectToIdpErrorPage,
-} from "./idpErrorPage";
+import { clearAuthState, getAccessToken } from "./authCookies";
 
 const TOKEN_EXPIRY_LEEWAY_SECONDS = 30;
-const REQUEST_TIMEOUT_MS = 10000;
-
-const refreshClient = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
-  withCredentials: true,
-  timeout: REQUEST_TIMEOUT_MS,
-});
-
-let refreshPromise = null;
 
 function decodeJwtPayload(token) {
   try {
@@ -51,41 +37,7 @@ export function isAccessTokenExpired(token = getAccessToken()) {
 }
 
 export async function refreshAccessToken() {
-  const refreshToken = getRefreshToken();
-
-  if (!refreshToken) {
-    return null;
-  }
-
-  if (!refreshPromise) {
-    refreshPromise = refreshClient
-      .post(
-        "/auth/refresh",
-        { refresh_token: refreshToken },
-        { skipAuthRefresh: true },
-      )
-      .then((response) => {
-        storeTokenResponse(response.data);
-        return response.data.access_token ?? null;
-      })
-      .catch((error) => {
-        clearAuthState();
-
-        if (
-          typeof window !== "undefined" &&
-          isIdpProtectedPath(window.location.pathname)
-        ) {
-          redirectToIdpErrorPage(error);
-        }
-
-        throw error;
-      })
-      .finally(() => {
-        refreshPromise = null;
-      });
-  }
-
-  return refreshPromise;
+  return null;
 }
 
 export async function ensureValidAccessToken() {
@@ -95,14 +47,6 @@ export async function ensureValidAccessToken() {
     return accessToken;
   }
 
-  if (!hasRefreshToken()) {
-    clearAuthState();
-    return null;
-  }
-
-  try {
-    return await refreshAccessToken();
-  } catch {
-    return null;
-  }
+  clearAuthState();
+  return null;
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,7 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
+import { clearLegacyRefreshTokenCookie } from "./auth/utils/authCookies";
 import "./index.css";
+
+clearLegacyRefreshTokenCookie();
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>

--- a/frontend/src/services/axiosInstance.js
+++ b/frontend/src/services/axiosInstance.js
@@ -1,11 +1,12 @@
 import axios from "axios";
 import { clearAuthState, getAccessToken } from "../auth/utils/authCookies";
-import { refreshAccessToken } from "../auth/utils/tokenRefresh";
-import { IDP_ERROR_PAGE_PATH, isIdpProtectedPath, redirectToIdpErrorPage } from "../auth/utils/idpErrorPage";
+import { getCurrentReturnPath, redirectToAuthorize } from "../auth/utils/authorizeFlow";
+import { IDP_ERROR_PAGE_PATH, isIdpProtectedPath } from "../auth/utils/idpErrorPage";
 import { buildLoginPath } from "../auth/utils/loginRoute";
 import { showForbiddenAlert } from "../utils/forbiddenAlert";
 
 const REQUEST_TIMEOUT_MS = 10000;
+const authClientId = import.meta.env.VITE_CLIENT_ID ?? "";
 
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
@@ -13,25 +14,34 @@ const axiosInstance = axios.create({
   timeout: REQUEST_TIMEOUT_MS,
 });
 
-function redirectAfterUnauthorized(error) {
+function redirectAfterUnauthorized() {
   if (typeof window === "undefined") {
-    return;
-  }
-
-  if (isIdpProtectedPath(window.location.pathname)) {
-    redirectToIdpErrorPage(error);
     return;
   }
 
   const publicPaths = new Set([
     "/",
     "/login",
+    "/register",
+    "/register/set-password",
     "/callback",
+    "/logout",
     IDP_ERROR_PAGE_PATH,
   ]);
 
-  if (!publicPaths.has(window.location.pathname)) {
-    window.location.replace(buildLoginPath());
+  if (publicPaths.has(window.location.pathname)) {
+    return;
+  }
+
+  clearAuthState();
+
+  const didRedirect = redirectToAuthorize(
+    authClientId,
+    getCurrentReturnPath(),
+  );
+
+  if (!didRedirect) {
+    window.location.replace(buildLoginPath(authClientId));
   }
 }
 
@@ -80,30 +90,12 @@ axiosInstance.interceptors.response.use(
     }
 
     if (!originalRequest || originalRequest.skipAuthRefresh || originalRequest._retry) {
-      redirectAfterUnauthorized(error);
+      redirectAfterUnauthorized();
       return Promise.reject(error);
     }
 
-    originalRequest._retry = true;
-
-    try {
-      const accessToken = await refreshAccessToken();
-
-      if (!accessToken) {
-        clearAuthState();
-        redirectAfterUnauthorized(error);
-        return Promise.reject(error);
-      }
-
-      originalRequest.headers = originalRequest.headers ?? {};
-      originalRequest.headers.Authorization = `Bearer ${accessToken}`;
-
-      return axiosInstance(originalRequest);
-    } catch (refreshError) {
-      clearAuthState();
-      redirectAfterUnauthorized(refreshError);
-      return Promise.reject(refreshError);
-    }
+    redirectAfterUnauthorized();
+    return Promise.reject(error);
   },
 );
 


### PR DESCRIPTION
This updates the frontend auth flow to stop storing the refresh token in browser-managed JS-readable cookies.

## Why
The refresh token was previously accessible from frontend JavaScript, which increases session hijack risk if XSS or a compromised script occurs.

## Changes
- Removed frontend refresh token persistence
- Switched expired/missing access token handling to re-auth through the existing backend session
- Preserved return-path behavior after re-authentication
- Cleared legacy refresh token cookies on app load
- Kept normal login flow working locally

## Testing
- Logged in successfully
- Removed `access_token` locally and confirmed the app re-authenticated through the existing backend session
- Confirmed cookies no longer show `refresh_token`

## Notes
- Frontend refresh-token rotation is no longer used; re-auth now relies on the backend session
