### PR TITLE
Fix/logout

### DIFF
--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -22,9 +22,9 @@ type Handlers struct {
 	OTPHandler          *v1.OTPHandler
 	UserRepo            repository.UserRepository
 
-	RoleRepo repository.RoleRepository
-	PubKey   *rsa.PublicKey
-	CORS     gin.HandlerFunc
+	RoleRepo   repository.RoleRepository
+	PubKey     *rsa.PublicKey
+	CORS       gin.HandlerFunc
 	ClientCORS gin.HandlerFunc
 }
 
@@ -41,12 +41,16 @@ func SetupRoutes(r *gin.Engine, h Handlers) {
 		auth.POST("/login", h.ClientCORS, h.AuthHandler.LoginAndAuthorize)
 		auth.POST("/token", h.AuthHandler.PostTokenExchange)
 		auth.POST("/refresh", h.AuthHandler.PostTokenRotate)
-		auth.POST("/logout", h.AuthHandler.Logout)
+		auth.POST("/logout",
+			middleware.AuthMiddleware(h.PubKey, h.LogHandler.LogService),
+			h.AuthHandler.Logout)
 		auth.GET("/session", h.AuthHandler.CheckSession)
 	}
 
 	v1Group.POST("/activate", h.RegistrationHandler.ActivateAccount)
 	v1Group.GET("/activate/:code", h.RegistrationHandler.CheckInvitation)
+	v1Group.POST("/internal/logout", h.ClientCORS,
+		h.AuthHandler.InternalLogout)
 
 	// Endpoint for getting user information
 	me := v1Group.Group("/me")
@@ -91,7 +95,6 @@ func SetupRoutes(r *gin.Engine, h Handlers) {
 		middleware.AuthMiddleware(h.PubKey, h.LogHandler.LogService),
 		middleware.APIKeyMiddleware(),
 		h.UserHandler.GetUserDetailedAccess)
-
 
 	// Protected Admin Endpoints
 	admin := v1Group.Group("/admin")

--- a/backend/internal/api/v1/auth_handler.go
+++ b/backend/internal/api/v1/auth_handler.go
@@ -261,32 +261,41 @@ func (h *AuthHandler) LoginAndAuthorize(c *gin.Context) {
 // @Summary Global Logout
 // @Description Clear session cookie and revoke all issued tokens for the user
 // @Tags Authentication
+// @Security Bearer
 // @Accept json
-// @Param req body dto.LogoutRequest true "Logout Request"
+// @Param req body dto.LogoutRequest false "Logout Request"
+// @Param client_id query string false "Client ID"
 // @Produce json
-// @Success 200 {object} dto.SuccessResponse
+// @Success 302
 // @Failure 500 {object} dto.ErrorResponse
 // @Router /auth/logout [post]
 func (h *AuthHandler) Logout(c *gin.Context) {
 	var req dto.LogoutRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		log.Printf("[Logout] Bind JSON: %v", err)
+	if err := c.ShouldBind(&req); err != nil {
+		req.ClientID = c.Query("client_id")
+	}
+
+	uIDStr := c.GetString("user_id")
+	userID, err := uuid.Parse(uIDStr)
+	if err != nil {
+		log.Printf("[Logout] User ID Parse: %v", err)
 		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
-			Error: "Invalid request format",
+			Error: "invalid user context",
 		})
 		return
 	}
 
-	// Get logout URL
-	clientID, err := uuid.Parse(req.ClientID)
+	cID, err := uuid.Parse(req.ClientID)
 	if err != nil {
-		log.Printf("[Logout] UUID Parse: %v", err)
+		log.Printf("[Logout] Client ID Parse: %v", err)
 		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
-			Error: "invalid client_id format",
+			Error: "invalid client_id",
 		})
 		return
 	}
-	client, err := h.ClientService.GetClientByID(c.Request.Context(), clientID)
+
+	// 1. Get client by id
+	_, err = h.ClientService.GetClientByID(c.Request.Context(), cID)
 	if err != nil {
 		log.Printf("[Logout] Client Lookup: %v", err)
 		c.JSON(http.StatusNotFound, dto.ErrorResponse{
@@ -294,87 +303,95 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 		})
 		return
 	}
-	logoutURL := client.LogoutURI
 
-	// Redirect to IdP
-	c.Redirect(http.StatusFound, os.Getenv("CLIENT_BASE_URL"))
-
-	// Retrieve all cookies
-	sessionID, err := c.Cookie(service.SESSION_COOKIE_NAME)
+	// 2. Revoke all user tokens
+	err = h.AuthService.RevokeAllUserTokens(c.Request.Context(), userID)
 	if err != nil {
-		c.Redirect(http.StatusFound, logoutURL)
+		log.Printf("[Logout] Token Revocation: %v", err)
 	}
 
-	// Get the session to know the user ID for audit logging
-	session, err := h.AuthService.ValidateSession(
-		c.Request.Context(),
-		sessionID,
-	)
-	if err != nil {
-		log.Printf("[Logout] ValidateSession: %v", err)
-		// Log failure with session ID as actor
-		logReq := &dto.PostAuditLogRequest{
-			Action: actionLogout,
-			Target: "global",
-			Status: models.StatusFail,
-			Metadata: buildMetadata(map[string]interface{}{
-				"ip":         c.ClientIP(),
-				"user_agent": c.Request.UserAgent(),
-				"error":      err.Error(),
-			}),
-		}
-		_ = h.LogService.PostAuditLogWithActorString(c.Request.Context(), sessionID, logReq)
-		_ = h.LogService.PostSecurityLogWithActorString(c.Request.Context(), sessionID, logReq)
-		h.AuthService.RevokeCookies(c)
-		c.Redirect(http.StatusFound, logoutURL)
-		return
-	}
+	// metadata for logging
+	metadata := buildMetadata(map[string]interface{}{
+		"client_id": req.ClientID,
+		"ip":        c.ClientIP(),
+	})
 
-	// Perform logout
-	err = h.AuthService.Logout(c.Request.Context(), sessionID)
-	if err != nil {
-		log.Printf("[Logout] %v", err)
-		logReq := &dto.PostAuditLogRequest{
-			Action: actionLogout,
-			Target: "global",
-			Status: models.StatusFail,
-			Metadata: buildMetadata(map[string]interface{}{
-				"ip":         c.ClientIP(),
-				"user_agent": c.Request.UserAgent(),
-				"error":      err.Error(),
-			}),
-		}
-		_ = h.LogService.PostAuditLog(c.Request.Context(), session.UserId, logReq)
-		_ = h.LogService.PostSecurityLog(c.Request.Context(), session.UserId, logReq)
-		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
-			Error: "logout failed",
+	_ = h.LogService.PostAuditLog(c.Request.Context(), userID[:],
+		&dto.PostAuditLogRequest{
+			Action:   actionLogout,
+			Target:   "global",
+			Status:   models.StatusSuccess,
+			Metadata: metadata,
 		})
-		h.AuthService.RevokeCookies(c)
-		return
-	}
-	h.AuthService.RevokeCookies(c)
 
-	// Log success (resolve user email for better readability)
-	userEmail, _ := h.LogService.GetUserEmail(c.Request.Context(), session.UserId)
-	actorName := userEmail
-	if actorName == "" {
-		// fallback to UUID string
-		uID, _ := uuid.FromBytes(session.UserId)
-		actorName = uID.String()
-	}
-	logReq := &dto.PostAuditLogRequest{
-		Action: actionLogout,
-		Target: "global",
-		Status: models.StatusSuccess,
-		Metadata: buildMetadata(map[string]interface{}{
-			"ip":         c.ClientIP(),
-			"user_agent": c.Request.UserAgent(),
-		}),
-	}
-	_ = h.LogService.PostAuditLogWithActorString(c.Request.Context(), actorName, logReq)
-	_ = h.LogService.PostSecurityLog(c.Request.Context(), session.UserId, logReq)
+	logoutURL := os.Getenv("CLIENT_BASE_URL") + "/logout?client_id=" +
+		req.ClientID + "&user_id=" + uIDStr
 
 	c.Redirect(http.StatusFound, logoutURL)
+}
+
+// InternalLogout handles server-side logout for specific users.
+func (h *AuthHandler) InternalLogout(c *gin.Context) {
+	var req dto.InternalLogoutRequest
+	if err := c.ShouldBind(&req); err != nil {
+		log.Printf("[InternalLogout] Bind: %v", err)
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error: "invalid request payload",
+		})
+		return
+	}
+
+	uID, err := uuid.Parse(req.UserID)
+	if err != nil {
+		log.Printf("[InternalLogout] User UUID Parse: %v", err)
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error: "invalid user_id",
+		})
+		return
+	}
+
+	cID, err := uuid.Parse(req.ClientID)
+	if err != nil {
+		log.Printf("[InternalLogout] Client UUID Parse: %v", err)
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error: "invalid client_id",
+		})
+		return
+	}
+
+	// 1. Get client by id
+	client, err := h.ClientService.GetClientByID(c.Request.Context(), cID)
+	if err != nil {
+		log.Printf("[InternalLogout] Client Lookup: %v", err)
+		c.JSON(http.StatusNotFound, dto.ErrorResponse{
+			Error: "client not found",
+		})
+		return
+	}
+
+	// 2. Revoke all user tokens (backend)
+	err = h.AuthService.RevokeAllUserTokens(c.Request.Context(), uID)
+	if err != nil {
+		log.Printf("[InternalLogout] Token Revocation: %v", err)
+	}
+
+	// 3. Clear session and access token cookies
+	h.AuthService.RevokeCookies(c)
+
+	// Audit Log
+	_ = h.LogService.PostAuditLog(c.Request.Context(), uID[:],
+		&dto.PostAuditLogRequest{
+			Action: actionLogout,
+			Target: "internal",
+			Status: models.StatusSuccess,
+			Metadata: buildMetadata(map[string]interface{}{
+				"client_id": req.ClientID,
+				"ip":        c.ClientIP(),
+			}),
+		})
+
+	// 4. Redirect based on client_id's logout uri
+	c.Redirect(http.StatusFound, client.LogoutURI)
 }
 
 // CheckSession verifies if the current session cookie is valid
@@ -494,7 +511,7 @@ func (h *AuthHandler) GetJWKS(c *gin.Context) {
 // @Summary Exchange Auth Code
 // @Description Validates the code and client secret to issue JWT and Refresh
 // @Tags Authentication
-// @Security 
+// @Security
 // @Accept json
 // @Produce json
 // @Param req body dto.TokenExchangeRequest true "Exchange Request"

--- a/backend/internal/dto/auth_dto.go
+++ b/backend/internal/dto/auth_dto.go
@@ -27,3 +27,8 @@ type RefreshRequest struct {
 type LogoutRequest struct {
 	ClientID string `json:"client_id" binding:"required"`
 }
+
+type InternalLogoutRequest struct {
+	ClientID string `json:"client_id" binding:"required"`
+	UserID   string `json:"user_id" binding:"required"`
+}

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -32,6 +32,7 @@ type AuthService interface {
 		oldToken string) (*dto.TokenResponse, error)
 	GetSessionToken(ctx context.Context, userID uuid.UUID,
 		ipAddress, userAgent string) (string, error)
+	RevokeAllUserTokens(ctx context.Context, userID uuid.UUID) error
 	RevokeCookies(c *gin.Context)
 }
 
@@ -46,7 +47,8 @@ type authService struct {
 func NewAuthService(repo repository.AuthCodeRepository,
 	sessionRepo repository.SessionRepository,
 	clientRepo repository.ClientRepository,
-	privateKey *rsa.PrivateKey, publicKey *rsa.PublicKey) AuthService {
+	privateKey *rsa.PrivateKey, publicKey *rsa.PublicKey,
+) AuthService {
 	return &authService{
 		Repo:        repo,
 		SessionRepo: sessionRepo,
@@ -168,6 +170,16 @@ func (s *authService) Logout(
 	_ = s.SessionRepo.Delete(ctx, sessionID)
 
 	return nil
+}
+
+/**
+ * RevokeAllUserTokens invalidates all active tokens for a specific user.
+ */
+func (s *authService) RevokeAllUserTokens(
+	ctx context.Context,
+	userID uuid.UUID,
+) error {
+	return s.Repo.RevokeTokens(ctx, userID[:])
 }
 
 /**
@@ -375,4 +387,3 @@ func (s *authService) RevokeCookies(c *gin.Context) {
 		true,
 	)
 }
-

--- a/frontend/src/auth/pages/Logout.jsx
+++ b/frontend/src/auth/pages/Logout.jsx
@@ -1,12 +1,16 @@
 import { useEffect, useRef } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { authService } from "../services/authService";
 import { clearAuthState } from "../utils/authCookies";
 import { buildLoginPath } from "../utils/loginRoute";
+import { getLogoutClientId, getLogoutUserId } from "../utils/logoutRoute";
 
 export default function Logout() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const hasRun = useRef(false);
+  const clientId = getLogoutClientId(searchParams);
+  const userId = getLogoutUserId(searchParams);
 
   useEffect(() => {
     if (hasRun.current) return;
@@ -14,17 +18,24 @@ export default function Logout() {
 
     const doLogout = async () => {
       try {
-        await authService.logout();
+        if (clientId && userId) {
+          await authService.logout({
+            clientId,
+            userId,
+          });
+        } else {
+          console.warn("Skipping logout API call because logout query params are incomplete.");
+        }
       } catch (err) {
         console.error("Logout failed", err);
       } finally {
         clearAuthState();
-        setTimeout(() => navigate(buildLoginPath(), { replace: true }), 500);
+        setTimeout(() => navigate(buildLoginPath(clientId), { replace: true }), 500);
       }
     };
 
     doLogout();
-  }, [navigate]);
+  }, [clientId, navigate, userId]);
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#250508] font-[Poppins] text-white">

--- a/frontend/src/auth/services/authService.js
+++ b/frontend/src/auth/services/authService.js
@@ -1,6 +1,8 @@
 import axiosInstance from "../../services/axiosInstance";
 
 const authClientId = import.meta.env.VITE_CLIENT_ID;
+const normalizeTextValue = (value) =>
+  typeof value === "string" ? value.trim() : "";
 
 function getLoginRedirectUrl(data) {
   if (typeof data === "string") {
@@ -43,9 +45,17 @@ export const authService = {
     return response.data;
   },
 
-  async logout() {
-    return axiosInstance.post("/auth/logout", {
-      client_id: authClientId,
+  async logout({ clientId = authClientId, userId = "" } = {}) {
+    const normalizedClientId = normalizeTextValue(clientId);
+    const normalizedUserId = normalizeTextValue(userId);
+
+    if (!normalizedClientId || !normalizedUserId) {
+      throw new Error("Client ID and user ID are required for logout.");
+    }
+
+    return axiosInstance.post("/internal/logout", {
+      client_id: normalizedClientId,
+      user_id: normalizedUserId,
     }, {
       skipAuthRefresh: true,
     });

--- a/frontend/src/auth/utils/logoutRoute.js
+++ b/frontend/src/auth/utils/logoutRoute.js
@@ -1,0 +1,32 @@
+const DEFAULT_CLIENT_ID = import.meta.env.VITE_CLIENT_ID ?? "";
+const LOGOUT_PATH = "/logout";
+
+function normalizeTextValue(value = "") {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function buildLogoutPath({ clientId = DEFAULT_CLIENT_ID, userId = "" } = {}) {
+  const params = new URLSearchParams();
+  const normalizedClientId = normalizeTextValue(clientId);
+  const normalizedUserId = normalizeTextValue(userId);
+
+  if (normalizedClientId) {
+    params.set("client_id", normalizedClientId);
+  }
+
+  if (normalizedUserId) {
+    params.set("user_id", normalizedUserId);
+  }
+
+  const queryString = params.toString();
+
+  return queryString ? `${LOGOUT_PATH}?${queryString}` : LOGOUT_PATH;
+}
+
+export function getLogoutClientId(searchParams) {
+  return normalizeTextValue(searchParams?.get("client_id")) || DEFAULT_CLIENT_ID;
+}
+
+export function getLogoutUserId(searchParams) {
+  return normalizeTextValue(searchParams?.get("user_id"));
+}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,5 +1,6 @@
 import { useLocation, useNavigate } from "react-router-dom";
 import { usePermissionAccess } from "../context/PermissionContext";
+import { buildLogoutPath } from "../auth/utils/logoutRoute";
 import { APP_CLIENT_PAGE_PERMISSIONS, PERMISSIONS, REGISTRATION_PAGE_PERMISSIONS, USER_POOL_PAGE_PERMISSIONS } from "../utils/permissionAccess";
 
 const menuSections = [
@@ -154,7 +155,7 @@ function SidebarMenuItem({ isOpen, item, isActive, onClick, isDarkMode, theme })
   );
 }
 
-export default function Sidebar({ isOpen, toggleSidebar, activeColorMode = "light" }) {
+export default function Sidebar({ isOpen, toggleSidebar, activeColorMode = "light", currentUser = null }) {
   const navigate = useNavigate();
   const location = useLocation();
   const { hasAnyPermission, isLoadingPermissions } = usePermissionAccess();
@@ -175,7 +176,12 @@ export default function Sidebar({ isOpen, toggleSidebar, activeColorMode = "ligh
   const mobileMenuItems = visibleMenuSections.flatMap((section) => section.items);
 
   const handleLogout = () => {
-    navigate("/logout", { replace: true });
+    navigate(
+      buildLogoutPath({
+        userId: currentUser?.id,
+      }),
+      { replace: true },
+    );
   };
 
   return (

--- a/frontend/src/components/TermAgreementModal.jsx
+++ b/frontend/src/components/TermAgreementModal.jsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { useNavigate } from "react-router-dom";
+import { buildLogoutPath } from "../auth/utils/logoutRoute";
 import { getModalTheme } from "./modalTheme";
 
-export default function TermsAgreementModal({ open, onClose, onContinue, colorMode = "light" }) {
+export default function TermsAgreementModal({ open, onClose, onContinue, colorMode = "light", currentUser = null }) {
   const navigate = useNavigate();
   const [agreed, setAgreed] = useState(false);
   const isDarkMode = colorMode === "dark";
@@ -54,7 +55,12 @@ export default function TermsAgreementModal({ open, onClose, onContinue, colorMo
 
   const handleCancel = () => {
     onClose?.();
-    navigate("/logout", { replace: true });
+    navigate(
+      buildLogoutPath({
+        userId: currentUser?.id,
+      }),
+      { replace: true },
+    );
   };
 
   const handleContinue = () => {

--- a/frontend/src/layouts/IdpLayout.jsx
+++ b/frontend/src/layouts/IdpLayout.jsx
@@ -152,6 +152,7 @@ export default function IdpLayout() {
         onClose={handleClose}
         onContinue={handleContinue}
         colorMode={colorMode}
+        currentUser={currentUser}
         privacyHref="/privacy"
         termsHref="/terms"
       />
@@ -161,6 +162,7 @@ export default function IdpLayout() {
           isOpen={sidebarOpen}
           toggleSidebar={toggleSidebar}
           activeColorMode={colorMode}
+          currentUser={currentUser}
         />
 
         <div className="flex min-w-0 flex-1 flex-col">


### PR DESCRIPTION
This pull request introduces a comprehensive overhaul of the logout flow for both backend and frontend, implementing a more secure and explicit logout process. The changes add a new internal logout endpoint, require both `client_id` and `user_id` for logout actions, and ensure that all user tokens are revoked server-side. The frontend is updated to use these new APIs, passing the necessary parameters and improving the handling of logout navigation. Additionally, audit logging and session cookie revocation are improved for better security and traceability.

**Backend changes:**

*Logout endpoint redesign and security:*
- The `/auth/logout` endpoint now requires authentication and uses middleware to ensure only authenticated users can log out. A new `/internal/logout` endpoint is added for server-side initiated logouts, requiring both `client_id` and `user_id` as parameters. (`backend/internal/api/routes.go` [backend/internal/api/routes.goL44-R53](diffhunk://#diff-f6343594ca58b3a83e23fc4a6c8056458ca9085fd8fbed0518bcf8405891e07aL44-R53))
- The logout logic in `AuthHandler.Logout` and the new `InternalLogout` method now validate both `client_id` and `user_id`, revoke all user tokens, perform audit logging, and redirect to the appropriate client logout URI. (`backend/internal/api/v1/auth_handler.go` [backend/internal/api/v1/auth_handler.goR264-R394](diffhunk://#diff-a56cf3acfe5a0ba8b75618214b0cba319502fadc836943545b7bc63e390399feR264-R394))
- Added `RevokeAllUserTokens` to the `AuthService` interface and implementation, ensuring all tokens for a user are invalidated on logout. (`backend/internal/service/auth_service.go` [[1]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaR35) [[2]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaR175-R184)

*DTO and interface updates:*
- Introduced the `InternalLogoutRequest` DTO to support the new internal logout endpoint. (`backend/internal/dto/auth_dto.go` [backend/internal/dto/auth_dto.goR30-R34](diffhunk://#diff-2e2e6aca32210bb8a0c690241d0da38d0a315e276c15a88b49cb2adf3b549c03R30-R34))

**Frontend changes:**

*Logout flow and navigation:*
- The logout page (`Logout.jsx`) now extracts `client_id` and `user_id` from the URL and calls the new `/internal/logout` API, ensuring both parameters are present before making the request. (`frontend/src/auth/pages/Logout.jsx` [frontend/src/auth/pages/Logout.jsxL2-R38](diffhunk://#diff-aef46a01443b27ac7b697a0cdc2b7cce4d6bbc881f8ed45723db7c245c5c2744L2-R38))
- The `authService.logout` method now requires both `clientId` and `userId`, and calls the `/internal/logout` endpoint. (`frontend/src/auth/services/authService.js` [frontend/src/auth/services/authService.jsL46-R58](diffhunk://#diff-45ed37fbf6fe57eec4422e4414e8a84b9aa6dd87e25313eb0c5bf9eec473d3a1L46-R58))
- Utility functions for building and parsing logout URLs with the required parameters are added. (`frontend/src/auth/utils/logoutRoute.js` [frontend/src/auth/utils/logoutRoute.jsR1-R32](diffhunk://#diff-00c0255a1e0805a8e1d4258458fdbe065920c6cd4f4e15f943a78de9a6201c4eR1-R32))

*Consistent logout navigation:*
- The sidebar and terms agreement modal now use the new logout URL builder and pass the current user's ID, ensuring all logout actions consistently use the updated flow. (`frontend/src/components/Sidebar.jsx` [[1]](diffhunk://#diff-e6bb5283abab1c5da2fc0dbd91743c3dc4f0f2a6714fded570124ec367a48de2L178-R184) `frontend/src/components/TermAgreementModal.jsx` [[2]](diffhunk://#diff-6d7ff4ce4eb4f3a63d03c330914d123930d29d40c97610e4c7844df9572cdb7eL57-R63) `frontend/src/layouts/IdpLayout.jsx` [[3]](diffhunk://#diff-f7bab84d794ebd0327c5df8351606f3f01b254633d1992ed80757e86461571bbR165) [[4]](diffhunk://#diff-f7bab84d794ebd0327c5df8351606f3f01b254633d1992ed80757e86461571bbR155)

---

**Most important changes:**

**Backend:**
- Added authentication middleware to `/auth/logout` and introduced `/internal/logout` endpoint requiring both `client_id` and `user_id`, with full token revocation and audit logging. [[1]](diffhunk://#diff-f6343594ca58b3a83e23fc4a6c8056458ca9085fd8fbed0518bcf8405891e07aL44-R53) [[2]](diffhunk://#diff-a56cf3acfe5a0ba8b75618214b0cba319502fadc836943545b7bc63e390399feR264-R394)
- Implemented `RevokeAllUserTokens` in `AuthService` for secure, global token invalidation. [[1]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaR35) [[2]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaR175-R184)
- Introduced `InternalLogoutRequest` DTO for internal logout operations.

**Frontend:**
- Updated logout flow to require and use both `client_id` and `user_id`, calling the new `/internal/logout` endpoint, and improved navigation after logout. [[1]](diffhunk://#diff-aef46a01443b27ac7b697a0cdc2b7cce4d6bbc881f8ed45723db7c245c5c2744L2-R38) [[2]](diffhunk://#diff-45ed37fbf6fe57eec4422e4414e8a84b9aa6dd87e25313eb0c5bf9eec473d3a1L46-R58)
- Refactored all logout navigation (sidebar, modal, etc.) to use the new logout URL builder and pass the current user's ID, ensuring consistency and correctness. [[1]](diffhunk://#diff-00c0255a1e0805a8e1d4258458fdbe065920c6cd4f4e15f943a78de9a6201c4eR1-R32) [[2]](diffhunk://#diff-e6bb5283abab1c5da2fc0dbd91743c3dc4f0f2a6714fded570124ec367a48de2L178-R184) [[3]](diffhunk://#diff-6d7ff4ce4eb4f3a63d03c330914d123930d29d40c97610e4c7844df9572cdb7eL57-R63) [[4]](diffhunk://#diff-f7bab84d794ebd0327c5df8351606f3f01b254633d1992ed80757e86461571bbR165) [[5]](diffhunk://#diff-f7bab84d794ebd0327c5df8351606f3f01b254633d1992ed80757e86461571bbR155)