### PR TITLE
Fix/internal refresh

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -440,6 +440,100 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "put": {
+                "description": "Update name and preapproved clients for an account type.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Registration"
+                ],
+                "summary": "Update Account Type",
+                "parameters": [
+                    {
+                        "description": "Update Request",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.UpsertAccountTypeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Create an account type with preapproved clients.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Registration"
+                ],
+                "summary": "Create Account Type",
+                "parameters": [
+                    {
+                        "description": "Create Request",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.UpsertAccountTypeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/admin/registration/config/{id}": {
@@ -481,30 +575,23 @@ const docTemplate = `{
                         }
                     }
                 }
-            }
-        },
-        "/admin/registration/preapproved": {
-            "put": {
-                "description": "Add/Remove client IDs for a specific account type.",
-                "consumes": [
-                    "application/json"
-                ],
+            },
+            "delete": {
+                "description": "Delete an account type and its client associations.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Registration"
                 ],
-                "summary": "Update Preapproved Clients",
+                "summary": "Delete Account Type",
                 "parameters": [
                     {
-                        "description": "Update Request",
-                        "name": "req",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/dto.UpdatePreapprovedClientsRequest"
-                        }
+                        "type": "integer",
+                        "description": "Account Type ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -716,6 +803,52 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/dto.SuccessResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/users": {
+            "post": {
+                "description": "Register a new user with an account type ID.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Create Admin User",
+                "parameters": [
+                    {
+                        "description": "User Data",
+                        "name": "user",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.PostAdminUserRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "500": {
@@ -945,6 +1078,11 @@ const docTemplate = `{
         },
         "/auth/logout": {
             "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
                 "description": "Clear session cookie and revoke all issued tokens for the user",
                 "consumes": [
                     "application/json"
@@ -961,18 +1099,20 @@ const docTemplate = `{
                         "description": "Logout Request",
                         "name": "req",
                         "in": "body",
-                        "required": true,
                         "schema": {
                             "$ref": "#/definitions/dto.LogoutRequest"
                         }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Client ID",
+                        "name": "client_id",
+                        "in": "query"
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
-                        }
+                    "302": {
+                        "description": "Found"
                     },
                     "500": {
                         "description": "Internal Server Error",
@@ -1141,6 +1281,58 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/dto.ClientSecretResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/internal/user/{email}/password": {
+            "patch": {
+                "description": "Updates the password for a user identified by email.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Update user password by email",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User Email",
+                        "name": "email",
+                        "in": "path"
+                    },
+                    {
+                        "description": "Update Data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.UpdatePasswordByEmailRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "500": {
@@ -1635,6 +1827,116 @@ const docTemplate = `{
                 }
             }
         },
+        "/user/password/change": {
+            "patch": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Updates the password for the currently authenticated user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Change user password",
+                "parameters": [
+                    {
+                        "description": "Password Change Data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.ChangePasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/user/{id}/name": {
+            "patch": {
+                "description": "Updates first, middle, last names and suffix of a user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Update user name",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Name update data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.UpdateUserNameRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/users": {
             "get": {
                 "description": "Get a paginated list of all users",
@@ -2006,16 +2308,39 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/dto.PreapprovedClientResponse"
                     }
+                },
+                "id": {
+                    "type": "integer"
                 }
             }
         },
         "dto.ActivateAccountRequest": {
             "type": "object",
+            "required": [
+                "invitation_code",
+                "password"
+            ],
             "properties": {
                 "invitation_code": {
                     "type": "string"
                 },
                 "password": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.ChangePasswordRequest": {
+            "type": "object",
+            "required": [
+                "new_password",
+                "old_password"
+            ],
+            "properties": {
+                "new_password": {
+                    "type": "string",
+                    "minLength": 8
+                },
+                "old_password": {
                     "type": "string"
                 }
             }
@@ -2139,14 +2464,14 @@ const docTemplate = `{
         "dto.InvitationRequest": {
             "type": "object",
             "required": [
-                "email",
-                "invitation_type"
+                "account_type_id",
+                "email"
             ],
             "properties": {
-                "email": {
-                    "type": "string"
+                "account_type_id": {
+                    "type": "integer"
                 },
-                "invitation_type": {
+                "email": {
                     "type": "string"
                 }
             }
@@ -2188,6 +2513,52 @@ const docTemplate = `{
             ],
             "properties": {
                 "email": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.PostAdminUserRequest": {
+            "type": "object",
+            "required": [
+                "email",
+                "first_name",
+                "last_name",
+                "password",
+                "status"
+            ],
+            "properties": {
+                "account_type_id": {
+                    "type": "integer"
+                },
+                "allowed_appclients": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "email": {
+                    "type": "string"
+                },
+                "first_name": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "middle_name": {
+                    "type": "string"
+                },
+                "name_suffix": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string",
+                    "minLength": 8
+                },
+                "role_id": {
+                    "type": "integer"
+                },
+                "status": {
                     "type": "string"
                 }
             }
@@ -2372,6 +2743,21 @@ const docTemplate = `{
                 }
             }
         },
+        "dto.UpdatePasswordByEmailRequest": {
+            "type": "object",
+            "required": [
+                "email",
+                "new_password"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "new_password": {
+                    "type": "string"
+                }
+            }
+        },
         "dto.UpdatePasswordRequest": {
             "type": "object",
             "required": [
@@ -2380,20 +2766,6 @@ const docTemplate = `{
             "properties": {
                 "new_password": {
                     "type": "string"
-                }
-            }
-        },
-        "dto.UpdatePreapprovedClientsRequest": {
-            "type": "object",
-            "properties": {
-                "account_type_id": {
-                    "type": "integer"
-                },
-                "client_ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
                 }
             }
         },
@@ -2422,11 +2794,54 @@ const docTemplate = `{
                 }
             }
         },
+        "dto.UpdateUserNameRequest": {
+            "type": "object",
+            "required": [
+                "first_name",
+                "last_name"
+            ],
+            "properties": {
+                "first_name": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "middle_name": {
+                    "type": "string"
+                },
+                "name_suffix": {
+                    "type": "string"
+                }
+            }
+        },
         "dto.UpdateUserRoleRequest": {
             "type": "object",
             "properties": {
                 "role_id": {
                     "type": "integer"
+                }
+            }
+        },
+        "dto.UpsertAccountTypeRequest": {
+            "type": "object",
+            "required": [
+                "client_ids",
+                "id",
+                "name"
+            ],
+            "properties": {
+                "client_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -434,6 +434,100 @@
                         }
                     }
                 }
+            },
+            "put": {
+                "description": "Update name and preapproved clients for an account type.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Registration"
+                ],
+                "summary": "Update Account Type",
+                "parameters": [
+                    {
+                        "description": "Update Request",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.UpsertAccountTypeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Create an account type with preapproved clients.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Registration"
+                ],
+                "summary": "Create Account Type",
+                "parameters": [
+                    {
+                        "description": "Create Request",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.UpsertAccountTypeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/admin/registration/config/{id}": {
@@ -475,30 +569,23 @@
                         }
                     }
                 }
-            }
-        },
-        "/admin/registration/preapproved": {
-            "put": {
-                "description": "Add/Remove client IDs for a specific account type.",
-                "consumes": [
-                    "application/json"
-                ],
+            },
+            "delete": {
+                "description": "Delete an account type and its client associations.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Registration"
                 ],
-                "summary": "Update Preapproved Clients",
+                "summary": "Delete Account Type",
                 "parameters": [
                     {
-                        "description": "Update Request",
-                        "name": "req",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/dto.UpdatePreapprovedClientsRequest"
-                        }
+                        "type": "integer",
+                        "description": "Account Type ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -710,6 +797,52 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/dto.SuccessResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/users": {
+            "post": {
+                "description": "Register a new user with an account type ID.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Create Admin User",
+                "parameters": [
+                    {
+                        "description": "User Data",
+                        "name": "user",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.PostAdminUserRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "500": {
@@ -939,6 +1072,11 @@
         },
         "/auth/logout": {
             "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
                 "description": "Clear session cookie and revoke all issued tokens for the user",
                 "consumes": [
                     "application/json"
@@ -955,18 +1093,20 @@
                         "description": "Logout Request",
                         "name": "req",
                         "in": "body",
-                        "required": true,
                         "schema": {
                             "$ref": "#/definitions/dto.LogoutRequest"
                         }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Client ID",
+                        "name": "client_id",
+                        "in": "query"
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
-                        }
+                    "302": {
+                        "description": "Found"
                     },
                     "500": {
                         "description": "Internal Server Error",
@@ -1135,6 +1275,58 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/dto.ClientSecretResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/internal/user/{email}/password": {
+            "patch": {
+                "description": "Updates the password for a user identified by email.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Update user password by email",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User Email",
+                        "name": "email",
+                        "in": "path"
+                    },
+                    {
+                        "description": "Update Data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.UpdatePasswordByEmailRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
                     "500": {
@@ -1629,6 +1821,116 @@
                 }
             }
         },
+        "/user/password/change": {
+            "patch": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Updates the password for the currently authenticated user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Change user password",
+                "parameters": [
+                    {
+                        "description": "Password Change Data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.ChangePasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/user/{id}/name": {
+            "patch": {
+                "description": "Updates first, middle, last names and suffix of a user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Update user name",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Name update data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.UpdateUserNameRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.SuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/users": {
             "get": {
                 "description": "Get a paginated list of all users",
@@ -2000,16 +2302,39 @@
                     "items": {
                         "$ref": "#/definitions/dto.PreapprovedClientResponse"
                     }
+                },
+                "id": {
+                    "type": "integer"
                 }
             }
         },
         "dto.ActivateAccountRequest": {
             "type": "object",
+            "required": [
+                "invitation_code",
+                "password"
+            ],
             "properties": {
                 "invitation_code": {
                     "type": "string"
                 },
                 "password": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.ChangePasswordRequest": {
+            "type": "object",
+            "required": [
+                "new_password",
+                "old_password"
+            ],
+            "properties": {
+                "new_password": {
+                    "type": "string",
+                    "minLength": 8
+                },
+                "old_password": {
                     "type": "string"
                 }
             }
@@ -2133,14 +2458,14 @@
         "dto.InvitationRequest": {
             "type": "object",
             "required": [
-                "email",
-                "invitation_type"
+                "account_type_id",
+                "email"
             ],
             "properties": {
-                "email": {
-                    "type": "string"
+                "account_type_id": {
+                    "type": "integer"
                 },
-                "invitation_type": {
+                "email": {
                     "type": "string"
                 }
             }
@@ -2182,6 +2507,52 @@
             ],
             "properties": {
                 "email": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.PostAdminUserRequest": {
+            "type": "object",
+            "required": [
+                "email",
+                "first_name",
+                "last_name",
+                "password",
+                "status"
+            ],
+            "properties": {
+                "account_type_id": {
+                    "type": "integer"
+                },
+                "allowed_appclients": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "email": {
+                    "type": "string"
+                },
+                "first_name": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "middle_name": {
+                    "type": "string"
+                },
+                "name_suffix": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string",
+                    "minLength": 8
+                },
+                "role_id": {
+                    "type": "integer"
+                },
+                "status": {
                     "type": "string"
                 }
             }
@@ -2366,6 +2737,21 @@
                 }
             }
         },
+        "dto.UpdatePasswordByEmailRequest": {
+            "type": "object",
+            "required": [
+                "email",
+                "new_password"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "new_password": {
+                    "type": "string"
+                }
+            }
+        },
         "dto.UpdatePasswordRequest": {
             "type": "object",
             "required": [
@@ -2374,20 +2760,6 @@
             "properties": {
                 "new_password": {
                     "type": "string"
-                }
-            }
-        },
-        "dto.UpdatePreapprovedClientsRequest": {
-            "type": "object",
-            "properties": {
-                "account_type_id": {
-                    "type": "integer"
-                },
-                "client_ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
                 }
             }
         },
@@ -2416,11 +2788,54 @@
                 }
             }
         },
+        "dto.UpdateUserNameRequest": {
+            "type": "object",
+            "required": [
+                "first_name",
+                "last_name"
+            ],
+            "properties": {
+                "first_name": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "middle_name": {
+                    "type": "string"
+                },
+                "name_suffix": {
+                    "type": "string"
+                }
+            }
+        },
         "dto.UpdateUserRoleRequest": {
             "type": "object",
             "properties": {
                 "role_id": {
                     "type": "integer"
+                }
+            }
+        },
+        "dto.UpsertAccountTypeRequest": {
+            "type": "object",
+            "required": [
+                "client_ids",
+                "id",
+                "name"
+            ],
+            "properties": {
+                "client_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -8,6 +8,8 @@ definitions:
         items:
           $ref: '#/definitions/dto.PreapprovedClientResponse'
         type: array
+      id:
+        type: integer
     type: object
   dto.ActivateAccountRequest:
     properties:
@@ -15,6 +17,20 @@ definitions:
         type: string
       password:
         type: string
+    required:
+    - invitation_code
+    - password
+    type: object
+  dto.ChangePasswordRequest:
+    properties:
+      new_password:
+        minLength: 8
+        type: string
+      old_password:
+        type: string
+    required:
+    - new_password
+    - old_password
     type: object
   dto.ClientAccessResponse:
     properties:
@@ -94,13 +110,13 @@ definitions:
     type: object
   dto.InvitationRequest:
     properties:
+      account_type_id:
+        type: integer
       email:
         type: string
-      invitation_type:
-        type: string
     required:
+    - account_type_id
     - email
-    - invitation_type
     type: object
   dto.LoginRequest:
     properties:
@@ -128,6 +144,38 @@ definitions:
         type: string
     required:
     - email
+    type: object
+  dto.PostAdminUserRequest:
+    properties:
+      account_type_id:
+        type: integer
+      allowed_appclients:
+        items:
+          type: string
+        type: array
+      email:
+        type: string
+      first_name:
+        type: string
+      last_name:
+        type: string
+      middle_name:
+        type: string
+      name_suffix:
+        type: string
+      password:
+        minLength: 8
+        type: string
+      role_id:
+        type: integer
+      status:
+        type: string
+    required:
+    - email
+    - first_name
+    - last_name
+    - password
+    - status
     type: object
   dto.PostAuditLogRequest:
     properties:
@@ -247,21 +295,22 @@ definitions:
       token_type:
         type: string
     type: object
+  dto.UpdatePasswordByEmailRequest:
+    properties:
+      email:
+        type: string
+      new_password:
+        type: string
+    required:
+    - email
+    - new_password
+    type: object
   dto.UpdatePasswordRequest:
     properties:
       new_password:
         type: string
     required:
     - new_password
-    type: object
-  dto.UpdatePreapprovedClientsRequest:
-    properties:
-      account_type_id:
-        type: integer
-      client_ids:
-        items:
-          type: string
-        type: array
     type: object
   dto.UpdateStatusRequest:
     properties:
@@ -279,10 +328,39 @@ definitions:
     required:
     - client_ids
     type: object
+  dto.UpdateUserNameRequest:
+    properties:
+      first_name:
+        type: string
+      last_name:
+        type: string
+      middle_name:
+        type: string
+      name_suffix:
+        type: string
+    required:
+    - first_name
+    - last_name
+    type: object
   dto.UpdateUserRoleRequest:
     properties:
       role_id:
         type: integer
+    type: object
+  dto.UpsertAccountTypeRequest:
+    properties:
+      client_ids:
+        items:
+          type: string
+        type: array
+      id:
+        type: integer
+      name:
+        type: string
+    required:
+    - client_ids
+    - id
+    - name
     type: object
   dto.UserInfoResponse:
     properties:
@@ -750,7 +828,97 @@ paths:
       summary: Get Registration Config
       tags:
       - Registration
+    post:
+      consumes:
+      - application/json
+      description: Create an account type with preapproved clients.
+      parameters:
+      - description: Create Request
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/dto.UpsertAccountTypeRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+      summary: Create Account Type
+      tags:
+      - Registration
+    put:
+      consumes:
+      - application/json
+      description: Update name and preapproved clients for an account type.
+      parameters:
+      - description: Update Request
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/dto.UpsertAccountTypeRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+      summary: Update Account Type
+      tags:
+      - Registration
   /admin/registration/config/{id}:
+    delete:
+      description: Delete an account type and its client associations.
+      parameters:
+      - description: Account Type ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+      summary: Delete Account Type
+      tags:
+      - Registration
     get:
       description: Fetch all clients preapproved for a given account type.
       parameters:
@@ -775,38 +943,6 @@ paths:
           schema:
             $ref: '#/definitions/dto.ErrorResponse'
       summary: Get Clients By Account Type ID
-      tags:
-      - Registration
-  /admin/registration/preapproved:
-    put:
-      consumes:
-      - application/json
-      description: Add/Remove client IDs for a specific account type.
-      parameters:
-      - description: Update Request
-        in: body
-        name: req
-        required: true
-        schema:
-          $ref: '#/definitions/dto.UpdatePreapprovedClientsRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/dto.ErrorResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/dto.ErrorResponse'
-      summary: Update Preapproved Clients
       tags:
       - Registration
   /admin/roles:
@@ -938,6 +1074,36 @@ paths:
       summary: Update an existing role
       tags:
       - Roles
+  /admin/users:
+    post:
+      consumes:
+      - application/json
+      description: Register a new user with an account type ID.
+      parameters:
+      - description: User Data
+        in: body
+        name: user
+        required: true
+        schema:
+          $ref: '#/definitions/dto.PostAdminUserRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/dto.SuccessResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+      summary: Create Admin User
+      tags:
+      - Users
   /admin/users/{id}/access:
     put:
       consumes:
@@ -1089,20 +1255,23 @@ paths:
       - description: Logout Request
         in: body
         name: req
-        required: true
         schema:
           $ref: '#/definitions/dto.LogoutRequest'
+      - description: Client ID
+        in: query
+        name: client_id
+        type: string
       produces:
       - application/json
       responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/dto.SuccessResponse'
+        "302":
+          description: Found
         "500":
           description: Internal Server Error
           schema:
             $ref: '#/definitions/dto.ErrorResponse'
+      security:
+      - Bearer: []
       summary: Global Logout
       tags:
       - Authentication
@@ -1217,6 +1386,40 @@ paths:
       summary: Update client secret
       tags:
       - Clients
+  /internal/user/{email}/password:
+    patch:
+      consumes:
+      - application/json
+      description: Updates the password for a user identified by email.
+      parameters:
+      - description: User Email
+        in: path
+        name: email
+        type: string
+      - description: Update Data
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dto.UpdatePasswordByEmailRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.SuccessResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+      summary: Update user password by email
+      tags:
+      - Users
   /logs:
     get:
       description: Returns a paginated list of audit logs with optional filters.
@@ -1534,6 +1737,77 @@ paths:
       summary: Verify OTP Code
       tags:
       - otp
+  /user/{id}/name:
+    patch:
+      consumes:
+      - application/json
+      description: Updates first, middle, last names and suffix of a user.
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Name update data
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dto.UpdateUserNameRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.SuccessResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+      summary: Update user name
+      tags:
+      - Users
+  /user/password/change:
+    patch:
+      consumes:
+      - application/json
+      description: Updates the password for the currently authenticated user.
+      parameters:
+      - description: Password Change Data
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dto.ChangePasswordRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.SuccessResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+      security:
+      - Bearer: []
+      summary: Change user password
+      tags:
+      - Users
   /users:
     get:
       description: Get a paginated list of all users

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -51,6 +51,8 @@ func SetupRoutes(r *gin.Engine, h Handlers) {
 	v1Group.GET("/activate/:code", h.RegistrationHandler.CheckInvitation)
 	v1Group.POST("/internal/logout", h.ClientCORS,
 		h.AuthHandler.InternalLogout)
+	v1Group.POST("/internal/auth/refresh", h.ClientCORS,
+		h.AuthHandler.PostInternalRefresh)
 
 	// Endpoint for getting user information
 	me := v1Group.Group("/me")

--- a/backend/internal/api/v1/auth_handler.go
+++ b/backend/internal/api/v1/auth_handler.go
@@ -706,3 +706,67 @@ func (h *AuthHandler) PostTokenRotate(c *gin.Context) {
 
 	c.JSON(http.StatusOK, resp)
 }
+
+// PostInternalRefresh handles session-based refresh for the primary SPA client.
+func (h *AuthHandler) PostInternalRefresh(c *gin.Context) {
+	var req dto.InternalRefreshRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		log.Printf("[PostInternalRefresh] Bind JSON: %v", err)
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Error: "invalid_request",
+		})
+		return
+	}
+
+	// Verify that the client is indeed the primary internal client
+	if req.ClientID != os.Getenv("CLIENT_ID") {
+		c.JSON(http.StatusForbidden, dto.ErrorResponse{
+			Error: "client_not_allowed_for_session_refresh",
+		})
+		return
+	}
+
+	sessionID, err := c.Cookie(service.SESSION_COOKIE_NAME)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, dto.ErrorResponse{
+			Error: "session_required",
+		})
+		return
+	}
+
+	resp, err := h.AuthService.RefreshBySession(
+		c.Request.Context(),
+		sessionID,
+		req.ClientID,
+	)
+	if err != nil {
+		log.Printf("[PostInternalRefresh] Service Error: %v", err)
+		c.JSON(http.StatusUnauthorized, dto.ErrorResponse{
+			Error: "refresh_fail",
+		})
+		return
+	}
+
+	// Resolve client name for logging
+	clientName := h.LogService.ResolveClientName(
+		c.Request.Context(),
+		req.ClientID,
+	)
+
+	// Log success
+	logReq := &dto.PostAuditLogRequest{
+		Action: actionTokenRotate,
+		Target: "session_refresh",
+		Status: models.StatusSuccess,
+		Metadata: buildMetadata(map[string]interface{}{
+			"client_id":   req.ClientID,
+			"client_name": clientName,
+			"ip":          c.ClientIP(),
+			"user_agent":  c.Request.UserAgent(),
+		}),
+	}
+	_ = h.LogService.PostAuditLogWithActorString(c.Request.Context(),
+		clientName, logReq)
+
+	c.JSON(http.StatusOK, resp)
+}

--- a/backend/internal/dto/auth_dto.go
+++ b/backend/internal/dto/auth_dto.go
@@ -24,6 +24,10 @@ type RefreshRequest struct {
 	RefreshToken string `json:"refresh_token" binding:"required"`
 }
 
+type InternalRefreshRequest struct {
+	ClientID string `json:"client_id" binding:"required"`
+}
+
 type LogoutRequest struct {
 	ClientID string `json:"client_id" binding:"required"`
 }

--- a/backend/internal/middleware/auth_mw.go
+++ b/backend/internal/middleware/auth_mw.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Iskolutions-Capstone-Dev-Team/Identity-Provider/internal/repository"
 	"github.com/Iskolutions-Capstone-Dev-Team/Identity-Provider/internal/service"
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 )
 
@@ -51,8 +52,18 @@ func AuthMiddleware(publicKey *rsa.PublicKey, logService service.LogService) gin
 		token, err := service.GetParsedToken(parts[1], publicKey)
 		if err != nil {
 			log.Printf("[AuthMiddleware] Token Validation: %v", err)
+			
+			status := http.StatusUnauthorized
+			errorMsg := "invalid_token"
+			
+			// Specifically handle expired tokens for frontend auto-refresh
+			if strings.Contains(err.Error(), jwt.ErrTokenExpired.Error()) {
+				errorMsg = "token_expired"
+			}
+
 			if logService != nil {
-				_ = logService.PostSecurityLogWithActorString(c.Request.Context(), c.ClientIP(), &dto.PostAuditLogRequest{
+				_ = logService.PostSecurityLogWithActorString(c.Request.Context(), 
+					c.ClientIP(), &dto.PostAuditLogRequest{
 					Action:   "invalid_token_usage",
 					Target:   "auth_header",
 					Status:   models.StatusFail,
@@ -63,7 +74,7 @@ func AuthMiddleware(publicKey *rsa.PublicKey, logService service.LogService) gin
 					}),
 				})
 			}
-			c.AbortWithStatus(http.StatusUnauthorized)
+			c.AbortWithStatusJSON(status, dto.ErrorResponse{Error: errorMsg})
 			return
 		}
 
@@ -104,8 +115,17 @@ func AuthorizeRBAC(publicKey *rsa.PublicKey,
 		token, err := service.GetParsedToken(tokenStr, publicKey)
 		if err != nil {
 			log.Printf("[AuthorizeRBAC] Token Validation: %v", err)
+
+			status := http.StatusUnauthorized
+			errorMsg := "invalid_token"
+			
+			if strings.Contains(err.Error(), jwt.ErrTokenExpired.Error()) {
+				errorMsg = "token_expired"
+			}
+
 			if logService != nil {
-				_ = logService.PostSecurityLogWithActorString(c.Request.Context(), c.ClientIP(), &dto.PostAuditLogRequest{
+				_ = logService.PostSecurityLogWithActorString(c.Request.Context(), 
+					c.ClientIP(), &dto.PostAuditLogRequest{
 					Action:   "invalid_token_usage",
 					Target:   "access_token_cookie",
 					Status:   models.StatusFail,
@@ -116,7 +136,7 @@ func AuthorizeRBAC(publicKey *rsa.PublicKey,
 					}),
 				})
 			}
-			c.AbortWithStatus(http.StatusUnauthorized)
+			c.AbortWithStatusJSON(status, dto.ErrorResponse{Error: errorMsg})
 			return
 		}
 

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -33,6 +33,8 @@ type AuthService interface {
 	GetSessionToken(ctx context.Context, userID uuid.UUID,
 		ipAddress, userAgent string) (string, error)
 	RevokeAllUserTokens(ctx context.Context, userID uuid.UUID) error
+	RefreshBySession(ctx context.Context, sessionID string, 
+		clientID string) (*dto.TokenResponse, error)
 	RevokeCookies(c *gin.Context)
 }
 
@@ -267,15 +269,21 @@ func (s *authService) ExchangeCodeForToken(
 	grants, _ := s.ClientRepo.GetGrantTypes(ctx, clientIDBin)
 	var refreshStr string
 	if slices.Contains(grants, "refresh_token") {
-		refreshStr, _ = utils.GenerateRandomString(SECRET_ENTROPY)
-		err = s.Repo.StoreRefreshToken(
-			ctx,
-			refreshStr,
-			authCode.UserId,
-			clientIDBin,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("Database Query (StoreRefresh): %w", err)
+		// Optimization: If this is the primary IDP client, skip DB storage.
+		// The frontend will use the session cookie for refresh.
+		if req.ClientID == os.Getenv("CLIENT_ID") {
+			refreshStr = "internal_session_managed"
+		} else {
+			refreshStr, _ = utils.GenerateRandomString(SECRET_ENTROPY)
+			err = s.Repo.StoreRefreshToken(
+				ctx,
+				refreshStr,
+				authCode.UserId,
+				clientIDBin,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("Database Query (StoreRefresh): %w", err)
+			}
 		}
 	}
 
@@ -339,6 +347,54 @@ func (s *authService) RotateRefreshToken(
 		RefreshToken: newToken,
 		ExpiresIn:    ACCESS_TOKEN_EXPIRY,
 		TokenType:    "Bearer",
+	}, nil
+}
+
+/**
+ * RefreshBySession issues a new access token based on a valid session ID.
+ */
+func (s *authService) RefreshBySession(
+	ctx context.Context,
+	sessionID string,
+	clientIDStr string,
+) (*dto.TokenResponse, error) {
+	// 1. Validate Session
+	session, err := s.SessionRepo.GetByID(ctx, sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("Database Query (GetSession): %w", err)
+	}
+
+	if time.Now().After(session.ExpiresAt) {
+		return nil, fmt.Errorf("Session Validation: expired")
+	}
+
+	// 2. Validate Client
+	cUUID, err := uuid.Parse(clientIDStr)
+	if err != nil {
+		return nil, fmt.Errorf("UUID Parse: %w", err)
+	}
+
+	client, err := s.ClientRepo.GetByID(ctx, cUUID[:])
+	if err != nil {
+		return nil, fmt.Errorf("Database Query (GetClient): %w", err)
+	}
+
+	// 3. Retrieve Identity
+	claims, err := s.Repo.GetClaimsByID(ctx, session.UserId)
+	if err != nil {
+		return nil, fmt.Errorf("Database Query (GetClaims): %w", err)
+	}
+
+	// 4. Mint new Access Token
+	accessToken, err := GenerateToken(s.PrivateKey, client, *claims)
+	if err != nil {
+		return nil, fmt.Errorf("Token Generation (JWT): %w", err)
+	}
+
+	return &dto.TokenResponse{
+		AccessToken: accessToken,
+		ExpiresIn:   ACCESS_TOKEN_EXPIRY,
+		TokenType:   "Bearer",
 	}, nil
 }
 

--- a/frontend/src/auth/services/authService.js
+++ b/frontend/src/auth/services/authService.js
@@ -66,4 +66,14 @@ export const authService = {
       skipAuthRefresh: true,
     });
   },
+
+  async refreshSession(clientId) {
+    const response = await axiosInstance.post("/internal/auth/refresh", {
+      client_id: clientId,
+    }, {
+      skipAuthRefresh: true,
+    });
+
+    return response.data;
+  },
 };

--- a/frontend/src/services/axiosInstance.js
+++ b/frontend/src/services/axiosInstance.js
@@ -4,6 +4,8 @@ import { getCurrentReturnPath, redirectToAuthorize } from "../auth/utils/authori
 import { IDP_ERROR_PAGE_PATH, isIdpProtectedPath } from "../auth/utils/idpErrorPage";
 import { buildLoginPath } from "../auth/utils/loginRoute";
 import { showForbiddenAlert } from "../utils/forbiddenAlert";
+import { storeTokenResponse } from "../auth/utils/authCookies";
+import { authService } from "../auth/services/authService";
 
 const REQUEST_TIMEOUT_MS = 10000;
 const authClientId = import.meta.env.VITE_CLIENT_ID ?? "";
@@ -89,9 +91,28 @@ axiosInstance.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    if (!originalRequest || originalRequest.skipAuthRefresh || originalRequest._retry) {
-      redirectAfterUnauthorized();
-      return Promise.reject(error);
+    const isTokenExpired = error.response?.data?.error === "token_expired";
+
+    if (
+      isTokenExpired &&
+      originalRequest &&
+      !originalRequest.skipAuthRefresh &&
+      !originalRequest._retry
+    ) {
+      originalRequest._retry = true;
+
+      try {
+        const tokenResponse = await authService.refreshSession(authClientId);
+        storeTokenResponse(tokenResponse);
+
+        // Update authorization header for retry
+        originalRequest.headers.Authorization = `Bearer ${tokenResponse.access_token}`;
+        return axiosInstance(originalRequest);
+      } catch (refreshError) {
+        console.error("[AxiosInterceptors] Token refresh failed:", refreshError);
+        redirectAfterUnauthorized();
+        return Promise.reject(refreshError);
+      }
     }
 
     redirectAfterUnauthorized();


### PR DESCRIPTION
## Summary
This PR adds silent access-token refresh for the internal SPA so expired tokens no longer force users back through login while their server-side session is still valid.

## What Changed
- Added a new internal refresh endpoint: `POST /internal/auth/refresh`
- Added backend session-based refresh logic that validates the session cookie, resolves the client, and mints a new access token
- Limited this flow to the configured internal `CLIENT_ID`
- Updated auth middleware to return `401` with `error: token_expired` for expired JWTs, so the frontend can distinguish token expiry from other auth failures
- Updated token exchange for the internal client to use a session-managed refresh path instead of storing a DB-backed refresh token
- Added `refreshSession()` to the frontend auth service
- Updated the Axios response interceptor to attempt a one-time silent refresh, store the new token, retry the original request, and fall back to the existing unauthorized redirect flow if refresh fails
- Regenerated Swagger docs

## Why
- Improves UX for the internal app by keeping users signed in when only the access token has expired
- Reuses the existing session cookie instead of redirecting immediately
- Leaves the existing refresh-token flow unchanged for non-internal clients

## Testing
- Login to the internal client and complete the normal auth flow
- Let the access token expire, then verify the next protected request refreshes silently and succeeds
- Remove or expire the session cookie and verify the app falls back to the normal unauthorized redirect
- Confirm non-internal clients still follow the existing refresh-token behavior

## Notes
- `backend/docs/*` contains generated Swagger output
- No database or migration changes are included in this branch
