### PR TITLE
Fix/admin priveleges

### DIFF
--- a/backend/internal/api/v1/auth_handler.go
+++ b/backend/internal/api/v1/auth_handler.go
@@ -168,7 +168,11 @@ func (h *AuthHandler) LoginAndAuthorize(c *gin.Context) {
 		})
 		return
 	}
-	client, err := h.ClientService.GetClientByID(c.Request.Context(), cID)
+	uIDStr := c.GetString("user_id")
+	uID, _ := uuid.Parse(uIDStr)
+	perms := c.GetStringSlice("permissions")
+
+	client, err := h.ClientService.GetClientByID(c.Request.Context(), cID, uID, perms)
 	if err != nil || !slices.Contains(client.Grants, "authorization_code") {
 		c.JSON(http.StatusForbidden, dto.ErrorResponse{
 			Error: "missing grant type",
@@ -294,8 +298,10 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 		return
 	}
 
+	actorPerms := c.GetStringSlice("permissions")
+
 	// 1. Get client by id
-	_, err = h.ClientService.GetClientByID(c.Request.Context(), cID)
+	_, err = h.ClientService.GetClientByID(c.Request.Context(), cID, userID, actorPerms)
 	if err != nil {
 		log.Printf("[Logout] Client Lookup: %v", err)
 		c.JSON(http.StatusNotFound, dto.ErrorResponse{
@@ -359,8 +365,11 @@ func (h *AuthHandler) InternalLogout(c *gin.Context) {
 		return
 	}
 
-	// 1. Get client by id
-	client, err := h.ClientService.GetClientByID(c.Request.Context(), cID)
+	actorIDStr := c.GetString("user_id")
+	actorID, _ := uuid.Parse(actorIDStr)
+	actorPerms := c.GetStringSlice("permissions")
+
+	client, err := h.ClientService.GetClientByID(c.Request.Context(), cID, actorID, actorPerms)
 	if err != nil {
 		log.Printf("[InternalLogout] Client Lookup: %v", err)
 		c.JSON(http.StatusNotFound, dto.ErrorResponse{
@@ -540,7 +549,11 @@ func (h *AuthHandler) PostTokenExchange(c *gin.Context) {
 		})
 		return
 	}
-	client, err := h.ClientService.GetClientByID(c.Request.Context(), cID)
+	uIDStr := c.GetString("user_id")
+	uID, _ := uuid.Parse(uIDStr)
+	perms := c.GetStringSlice("permissions")
+
+	client, err := h.ClientService.GetClientByID(c.Request.Context(), cID, uID, perms)
 	if err != nil || !slices.Contains(client.Grants, "client_credentials") {
 		c.JSON(http.StatusForbidden, dto.ErrorResponse{
 			Error: "missing grant type",

--- a/backend/internal/api/v1/client_handler.go
+++ b/backend/internal/api/v1/client_handler.go
@@ -141,7 +141,8 @@ func (h *ClientHandler) PostClient(c *gin.Context) {
 // @Failure 500 {object} dto.ErrorResponse
 // @Router /admin/clients [get]
 func (h *ClientHandler) GetClientList(c *gin.Context) {
-	if !middleware.HasPermission(c, "View all appclients") {
+	if !middleware.HasPermission(c, "View all appclients") &&
+		!middleware.HasPermission(c, "View connected appclients") {
 		c.JSON(
 			http.StatusUnauthorized,
 			dto.ErrorResponse{Error: "Unauthorized"},
@@ -221,6 +222,7 @@ func (h *ClientHandler) GetClient(c *gin.Context) {
 
 	userIDStr := c.GetString("user_id")
 	userID, _ := uuid.Parse(userIDStr)
+	permissions := c.GetStringSlice("permissions")
 	actorName, _ := h.LogService.GetUserEmail(ctx, userID[:])
 	if actorName == "" {
 		actorName = userIDStr
@@ -236,6 +238,8 @@ func (h *ClientHandler) GetClient(c *gin.Context) {
 	client, err := h.Service.GetClientByID(
 		ctx,
 		clientUUID,
+		userID,
+		permissions,
 	)
 	if err != nil {
 		log.Printf("[GetClient] %v", err)
@@ -302,6 +306,7 @@ func (h *ClientHandler) PutClient(c *gin.Context) {
 
 	userIDStr := c.GetString("user_id")
 	userID, _ := uuid.Parse(userIDStr)
+	permissions := c.GetStringSlice("permissions")
 	actorName, _ := h.LogService.GetUserEmail(ctx, userID[:])
 	if actorName == "" {
 		actorName = userIDStr
@@ -338,6 +343,8 @@ func (h *ClientHandler) PutClient(c *gin.Context) {
 		req,
 		file,
 		header,
+		userID,
+		permissions,
 	)
 	if err != nil {
 		log.Printf("[PutClient] %v", err)
@@ -397,6 +404,7 @@ func (h *ClientHandler) PatchClientSecret(c *gin.Context) {
 
 	userIDStr := c.GetString("user_id")
 	userID, _ := uuid.Parse(userIDStr)
+	permissions := c.GetStringSlice("permissions")
 	actorName, _ := h.LogService.GetUserEmail(ctx, userID[:])
 	if actorName == "" {
 		actorName = userIDStr
@@ -412,6 +420,8 @@ func (h *ClientHandler) PatchClientSecret(c *gin.Context) {
 	resp, err := h.Service.RotateClientSecret(
 		ctx,
 		clientID,
+		userID,
+		permissions,
 	)
 	if err != nil {
 		log.Printf("[PatchClientSecret] %v", err)
@@ -482,6 +492,7 @@ func (h *ClientHandler) DeleteClient(c *gin.Context) {
 
 	userIDStr := c.GetString("user_id")
 	userID, _ := uuid.Parse(userIDStr)
+	permissions := c.GetStringSlice("permissions")
 	actorName, _ := h.LogService.GetUserEmail(ctx, userID[:])
 	if actorName == "" {
 		actorName = userIDStr
@@ -494,7 +505,7 @@ func (h *ClientHandler) DeleteClient(c *gin.Context) {
 		"user_agent":  c.Request.UserAgent(),
 	})
 
-	err = h.Service.DeleteClient(ctx, clientUUID)
+	err = h.Service.DeleteClient(ctx, clientUUID, userID, permissions)
 	if err != nil {
 		log.Printf("[DeleteClient] %v", err)
 		_ = h.LogService.PostAuditLogWithActorString(ctx, actorName,

--- a/backend/internal/database/migrations/tables/permissions_table.go
+++ b/backend/internal/database/migrations/tables/permissions_table.go
@@ -68,5 +68,11 @@ var PermissionsMigration = migrations.TableMigration{
 				('Delete Registration Config')
 			;`,
 		},
+		{
+			ID: "add-scoped-client-permissions",
+			SQL: `INSERT IGNORE INTO permissions (permission) VALUES 
+				('View connected appclients')
+			;`,
+		},
 	},
 }

--- a/backend/internal/repository/client_repository.go
+++ b/backend/internal/repository/client_repository.go
@@ -33,9 +33,10 @@ type ClientRepository interface {
 	DeleteAndInsertGrants(ctx context.Context, c *models.Client,
 		grants []string) error
 	AdminiClientBind(ctx context.Context, userID, clientID []byte) error
-	BatchAdminClientBind(ctx context.Context, userID []byte, 
+	BatchAdminClientBind(ctx context.Context, userID []byte,
 		clientIDs [][]byte) error
 	RemoveAdminClientBind(ctx context.Context, clientID []byte) error
+	IsClientAllowed(ctx context.Context, userID, clientID []byte) (bool, error)
 }
 
 type clientRepository struct {
@@ -387,6 +388,19 @@ func (r *clientRepository) RemoveAdminClientBind(ctx context.Context,
 
 	_, err := r.db.ExecContext(ctx, query, clientID)
 	return err
+}
+
+func (r *clientRepository) IsClientAllowed(ctx context.Context,
+	userID, clientID []byte,
+) (bool, error) {
+	var allowed bool
+	query := `
+		SELECT EXISTS(
+			SELECT 1 FROM admin_allowed_clients 
+			WHERE user_id = ? AND client_id = ?
+		)`
+	err := r.db.GetContext(ctx, &allowed, query, userID, clientID)
+	return allowed, err
 }
 
 func NewClientRepository(db *sqlx.DB) ClientRepository {

--- a/backend/internal/service/client_service.go
+++ b/backend/internal/service/client_service.go
@@ -26,12 +26,15 @@ type ClientService interface {
 		keyword string) (*dto.ClientListResponse, error)
 	GetBoundClients(ctx context.Context, userID uuid.UUID, limit, page int,
 		keyword string) (*dto.ClientListResponse, error)
-	GetClientByID(ctx context.Context, id uuid.UUID) (*dto.ClientResponse, error)
+	GetClientByID(ctx context.Context, id uuid.UUID,
+		userID uuid.UUID, permissions []string) (*dto.ClientResponse, error)
 	UpdateClient(ctx context.Context, id uuid.UUID, req dto.CreateClientRequest,
-		file multipart.File, header *multipart.FileHeader) error
-	RotateClientSecret(ctx context.Context,
-		id uuid.UUID) (*dto.ClientSecretResponse, error)
-	DeleteClient(ctx context.Context, id uuid.UUID) error
+		file multipart.File, header *multipart.FileHeader,
+		userID uuid.UUID, permissions []string) error
+	RotateClientSecret(ctx context.Context, id uuid.UUID,
+		userID uuid.UUID, permissions []string) (*dto.ClientSecretResponse, error)
+	DeleteClient(ctx context.Context, id uuid.UUID,
+		userID uuid.UUID, permissions []string) error
 }
 
 type clientService struct {
@@ -117,7 +120,38 @@ func (s *clientService) GetFilteredClientList(
 		return s.GetClientList(ctx, limit, page, keyword)
 	}
 
-	return nil, fmt.Errorf("Privilege Validation: unauthorized level")
+	if slices.Contains(permissions, "View connected appclients") {
+		return s.GetBoundClients(ctx, userID, limit, page, keyword)
+	}
+
+	return nil, fmt.Errorf("Privilege Validation: restricted level")
+}
+
+func (s *clientService) checkClientAccess(
+	ctx context.Context,
+	userID uuid.UUID,
+	clientID uuid.UUID,
+	permissions []string,
+) error {
+	// If global admin permission is present, skip check.
+	if slices.Contains(permissions, "View all appclients") {
+		return nil
+	}
+
+	// If scoped permission is present, enforce check.
+	if slices.Contains(permissions, "View connected appclients") {
+		allowed, err := s.Repo.IsClientAllowed(ctx, userID[:], clientID[:])
+		if err != nil {
+			return fmt.Errorf("Repository Check: %w", err)
+		}
+		if !allowed {
+			return fmt.Errorf("Authorization: client is outside of your scope")
+		}
+		return nil
+	}
+
+	// Default: if no scoping rule is activated, default to global behavior.
+	return nil
 }
 
 /**
@@ -241,7 +275,13 @@ func (s *clientService) GetBoundClients(
 func (s *clientService) GetClientByID(
 	ctx context.Context,
 	id uuid.UUID,
+	userID uuid.UUID,
+	permissions []string,
 ) (*dto.ClientResponse, error) {
+	if err := s.checkClientAccess(ctx, userID, id, permissions); err != nil {
+		return nil, err
+	}
+
 	cl, err := s.Repo.GetByID(ctx, id[:])
 	if err != nil {
 		return nil, fmt.Errorf("Database Query (GetByID): %w", err)
@@ -296,7 +336,13 @@ func (s *clientService) UpdateClient(
 	req dto.CreateClientRequest,
 	file multipart.File,
 	header *multipart.FileHeader,
+	userID uuid.UUID,
+	permissions []string,
 ) error {
+	if err := s.checkClientAccess(ctx, userID, id, permissions); err != nil {
+		return err
+	}
+
 	existing, err := s.Repo.GetByID(ctx, id[:])
 	if err != nil {
 		return fmt.Errorf("Database Query (Search): %w", err)
@@ -342,7 +388,13 @@ func (s *clientService) UpdateClient(
 func (s *clientService) RotateClientSecret(
 	ctx context.Context,
 	id uuid.UUID,
+	userID uuid.UUID,
+	permissions []string,
 ) (*dto.ClientSecretResponse, error) {
+	if err := s.checkClientAccess(ctx, userID, id, permissions); err != nil {
+		return nil, err
+	}
+
 	// 1. Generate High-Entropy Secret
 	newSecret, err := utils.GenerateRandomString(SECRET_ENTROPY)
 	if err != nil {
@@ -375,7 +427,13 @@ func (s *clientService) RotateClientSecret(
 func (s *clientService) DeleteClient(
 	ctx context.Context,
 	id uuid.UUID,
+	userID uuid.UUID,
+	permissions []string,
 ) error {
+	if err := s.checkClientAccess(ctx, userID, id, permissions); err != nil {
+		return err
+	}
+
 	cl, err := s.Repo.GetByID(ctx, id[:])
 	if err != nil {
 		return fmt.Errorf("Database Query (Search): %w", err)

--- a/frontend/src/hooks/useManagedUserAccessClients.js
+++ b/frontend/src/hooks/useManagedUserAccessClients.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { userService } from "../services/userService";
 
 function mapManagedClient(client = {}) {
@@ -14,6 +14,8 @@ function mapManagedClient(client = {}) {
 export function useManagedUserAccessClients({ enabled = true } = {}) {
   const [appClients, setAppClients] = useState([]);
   const [isLoadingAppClients, setIsLoadingAppClients] = useState(enabled);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const skipNextLoadingRef = useRef(false);
 
   useEffect(() => {
     if (!enabled) {
@@ -23,10 +25,14 @@ export function useManagedUserAccessClients({ enabled = true } = {}) {
     }
 
     let cancelled = false;
+    const shouldShowLoading = !skipNextLoadingRef.current;
+    skipNextLoadingRef.current = false;
 
     const fetchManagedClients = async () => {
       try {
-        setIsLoadingAppClients(true);
+        if (shouldShowLoading) {
+          setIsLoadingAppClients(true);
+        }
 
         const managedClients = await userService.getManagedUserAccessClients();
         const clientMap = new Map();
@@ -66,10 +72,25 @@ export function useManagedUserAccessClients({ enabled = true } = {}) {
     return () => {
       cancelled = true;
     };
-  }, [enabled]);
+  }, [enabled, refreshKey]);
+
+  const refreshAppClients = ({ showLoading = true } = {}) => {
+    if (!enabled) {
+      setAppClients([]);
+      setIsLoadingAppClients(false);
+      return;
+    }
+
+    if (!showLoading) {
+      skipNextLoadingRef.current = true;
+    }
+
+    setRefreshKey((currentValue) => currentValue + 1);
+  };
 
   return {
     appClients,
     isLoadingAppClients,
+    refreshAppClients,
   };
 }

--- a/frontend/src/pages/AppClient.jsx
+++ b/frontend/src/pages/AppClient.jsx
@@ -25,8 +25,11 @@ export default function AppClient() {
     const canViewAllClients = hasPermission(PERMISSIONS.VIEW_ALL_APPCLIENTS);
     const shouldUseManagedClients =
         !canViewAllClients && (canEditClient || canDeleteClient);
-    const { appClients: managedClients, isLoadingAppClients: isLoadingManagedClients } =
-        useManagedUserAccessClients({ enabled: shouldUseManagedClients });
+    const {
+        appClients: managedClients,
+        isLoadingAppClients: isLoadingManagedClients,
+        refreshAppClients: refreshManagedClients,
+    } = useManagedUserAccessClients({ enabled: shouldUseManagedClients });
     const scopedClients = canViewAllClients
         ? null
         : shouldUseManagedClients
@@ -59,6 +62,11 @@ export default function AppClient() {
 
     const handleCreateClient = async (payload) => {
         const res = await createClient(payload);
+
+        if (shouldUseManagedClients) {
+            refreshManagedClients({ showLoading: false });
+        }
+
         setSecretModal({
             open: true,
             title: "Client secret created",
@@ -103,10 +111,21 @@ export default function AppClient() {
         setShowDeleteAlert(true);
     };
 
-    const confirmDelete = () => {
-        deleteClient(deleteTarget);
-        setShowDeleteAlert(false);
-        setDeleteTarget(null);
+    const confirmDelete = async () => {
+        if (!deleteTarget) {
+            return;
+        }
+
+        try {
+            await deleteClient(deleteTarget);
+
+            if (shouldUseManagedClients) {
+                refreshManagedClients({ showLoading: false });
+            }
+        } finally {
+            setShowDeleteAlert(false);
+            setDeleteTarget(null);
+        }
     };
 
     const handleRotateClick = (client) => {


### PR DESCRIPTION
This PR adds scoped appclient access support for admin users who should only work with their connected appclients, and fixes the frontend so newly created or deleted appclients show up immediately without requiring a browser reload.

- Added a new View connected appclients permission in the permissions migration.
- Updated client list access so users with either View all appclients or View connected appclients can load the appclient page appropriately.
- Added repository/service-level client authorization checks to ensure scoped users can only view or modify clients assigned to them.
- Applied scoped access checks to client detail, update, rotate secret, and delete flows.
- Updated auth handler calls to pass the acting user and permissions into client lookups so the new service signature stays consistent across login/logout/token-related flows.
- Added a refetch path for managed appclients in the frontend.
- Refreshed the scoped appclient table after create and delete so restricted users no longer need to reload the page to see updates.
