### PR TITLE
update access for one portal lookup query

### DIFF
--- a/backend/internal/repository/client_repository.go
+++ b/backend/internal/repository/client_repository.go
@@ -116,7 +116,7 @@ func (r *clientRepository) ListBoundClients(ctx context.Context,
 			c.description, c.image_location,
 			c.base_url, c.redirect_uri, c.logout_uri, c.created_at
 		FROM clients c
-		JOIN client_allowed_user a ON c.id = a.client_id
+		JOIN client_allowed_users a ON c.id = a.client_id
 		WHERE a.user_id = ?
 			AND c.deleted_at IS NULL
 			AND c.client_name LIKE ?

--- a/backend/internal/repository/client_repository.go
+++ b/backend/internal/repository/client_repository.go
@@ -116,7 +116,7 @@ func (r *clientRepository) ListBoundClients(ctx context.Context,
 			c.description, c.image_location,
 			c.base_url, c.redirect_uri, c.logout_uri, c.created_at
 		FROM clients c
-		JOIN admin_allowed_clients a ON c.id = a.client_id
+		JOIN client_allowed_user a ON c.id = a.client_id
 		WHERE a.user_id = ?
 			AND c.deleted_at IS NULL
 			AND c.client_name LIKE ?
@@ -273,7 +273,7 @@ func (r *clientRepository) CountBoundClients(ctx context.Context,
 	query := `
 		SELECT COUNT(*)
 		FROM clients c
-		JOIN admin_allowed_clients a ON c.id = a.client_id
+		JOIN client_allowed_users a ON c.id = a.client_id
 		WHERE a.user_id = ? 
 			AND c.deleted_at IS NULL 
 			AND c.client_name LIKE ?


### PR DESCRIPTION
This pull request updates the database join logic in the `clientRepository` methods to use the correct association table for allowed users. This change ensures that client queries reference the intended user-to-client relationship.

**Database join corrections:**

* Updated the `ListBoundClients` method in `client_repository.go` to join on the `client_allowed_user` table instead of `admin_allowed_clients`, ensuring the correct association is used when listing clients bound to a user.
* Updated the `CountBoundClients` method in `client_repository.go` to join on the `client_allowed_users` table instead of `admin_allowed_clients`, ensuring accurate client counts for a user.