### PR TITLE
fix staticcheck suggestions for identity provider backend

### DIFF
--- a/backend/internal/database/connection.go
+++ b/backend/internal/database/connection.go
@@ -25,7 +25,7 @@ func ConnectAdminToDB() (*sqlx.DB, error) {
 
 	db, err := sqlx.Open("mysql", config.FormatDSN())
 	if err != nil {
-		return nil, fmt.Errorf("Error connecting to database: %w", err)
+		return nil, fmt.Errorf("error connecting to database: %w", err)
 	}
 
 	return db, nil
@@ -46,7 +46,7 @@ func ConnectToDB() (*sqlx.DB, error) {
 
 	db, err := sqlx.Open("mysql", config.FormatDSN())
 	if err != nil {
-		return nil, fmt.Errorf("Error connecting to database: %w", err)
+		return nil, fmt.Errorf("error connecting to database: %w", err)
 	}
 
 	maxConnections := 25
@@ -60,7 +60,7 @@ func ConnectToDB() (*sqlx.DB, error) {
 		db.Close()
 
 		return nil, fmt.Errorf(
-			"Error pinging the database at %s: %w", 
+			"error pinging the database at %s: %w", 
 			config.Addr, 
 			err,
 		)

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -39,7 +39,7 @@ func MapStatus(status string) (UserStatus, error) {
 	case string(StatusDeleted):
 		s = StatusDeleted
 	default:
-		return "", fmt.Errorf("Invalid status string: %s", status)
+		return "", fmt.Errorf("invalid status string: %s", status)
 	}
 
 	return s, nil

--- a/backend/internal/repository/client_allowed_user_repository.go
+++ b/backend/internal/repository/client_allowed_user_repository.go
@@ -69,11 +69,11 @@ func (r *clientAllowedUserRepository) SyncUserAccess(ctx context.Context,
 	scopeQuery := "SELECT client_id FROM admin_allowed_clients WHERE user_id = ?"
 	err = tx.SelectContext(ctx, &scopedClients, scopeQuery, adminID)
 	if err != nil {
-		return fmt.Errorf("Sync: fetch scope: %w", err)
+		return fmt.Errorf("sync: fetch scope: %w", err)
 	}
 
 	if len(scopedClients) == 0 {
-		return fmt.Errorf("Sync: admin has no managed clients")
+		return fmt.Errorf("sync: admin has no managed clients")
 	}
 
 	// 2. Clear current user mappings THAT FALL WITHIN admin's scope
@@ -83,12 +83,12 @@ func (r *clientAllowedUserRepository) SyncUserAccess(ctx context.Context,
 		userID, scopedClients,
 	)
 	if err != nil {
-		return fmt.Errorf("Sync: delete query prep: %w", err)
+		return fmt.Errorf("sync: delete query prep: %w", err)
 	}
 	deleteQuery = r.db.Rebind(deleteQuery)
 	_, err = tx.ExecContext(ctx, deleteQuery, args...)
 	if err != nil {
-		return fmt.Errorf("Sync: delete execution: %w", err)
+		return fmt.Errorf("sync: delete execution: %w", err)
 	}
 
 	// 3. Insert new mappings (only if provided clientID is within scope)
@@ -103,7 +103,7 @@ func (r *clientAllowedUserRepository) SyncUserAccess(ctx context.Context,
 			                VALUES (?, ?)`
 			_, err = tx.ExecContext(ctx, insertQuery, reqID, userID)
 			if err != nil {
-				return fmt.Errorf("Sync: insert %x: %w", reqID, err)
+				return fmt.Errorf("sync: insert %x: %w", reqID, err)
 			}
 		}
 	}

--- a/backend/internal/repository/role_repository.go
+++ b/backend/internal/repository/role_repository.go
@@ -239,7 +239,7 @@ func (r *roleRepository) UpdateRole(ctx context.Context,
 		return err
 	}
 	if rows == 0 {
-		return errors.New("Forbidden role_name change or role not found.")
+		return errors.New("forbidden role_name change or role not found")
 	}
 
 	if _, err := tx.ExecContext(ctx,

--- a/backend/internal/repository/user_repository.go
+++ b/backend/internal/repository/user_repository.go
@@ -502,7 +502,7 @@ func (r *userRepository) populateClients(ctx context.Context,
 	var rows []clientAccessRow
 	err = r.db.SelectContext(ctx, &rows, fullQuery, args...)
 	if err != nil {
-		return fmt.Errorf("Database Map Fetch: %w", err)
+		return fmt.Errorf("database map fetch: %w", err)
 	}
 
 	clientMap := make(map[string][]models.Client)

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -71,36 +71,39 @@ func (s *authService) Authorize(
 ) (string, error) {
 	clientID, err := uuid.Parse(clientIDStr)
 	if err != nil {
-		return "", fmt.Errorf("UUID Parse: %w", err)
+		return "", fmt.Errorf("uuid parse: %w", err)
 	}
 
 	// 1. Session Validation
 	session, err := s.SessionRepo.GetByID(ctx, sessionToken)
+	if err != nil {
+		return "", fmt.Errorf("database query (GetSession): %w", err)
+	}
 	if session == nil {
-		return "", fmt.Errorf("No session Found")
+		return "", fmt.Errorf("no session found")
 	}
 
 	currentTime := time.Now()
 	if currentTime.After(session.ExpiresAt) {
-		return "", fmt.Errorf("Expired session")
+		return "", fmt.Errorf("expired session")
 	}
 
 	// 2. Client Verification
 	client, err := s.ClientRepo.GetByID(ctx, clientID[:])
 	if err != nil {
-		return "", fmt.Errorf("Database Query (GetClient): %w", err)
+		return "", fmt.Errorf("database query (GetClient): %w", err)
 	}
 
 	// 3. Code Generation
 	code, err := utils.GenerateAuthorizationCode()
 	if err != nil {
-		return "", fmt.Errorf("Code Generation: %w", err)
+		return "", fmt.Errorf("code generation: %w", err)
 	}
 
 	userID := session.UserId
 	err = s.Repo.StoreCode(ctx, code, userID[:], clientID[:], client.RedirectUri)
 	if err != nil {
-		return "", fmt.Errorf("Code Storage: %w", err)
+		return "", fmt.Errorf("code storage: %w", err)
 	}
 
 	return fmt.Sprintf("%s?code=%s", client.RedirectUri, code), nil
@@ -119,18 +122,18 @@ func (s *authService) LoginAndAuthorize(
 	// 1. Authenticate User
 	claims, storedHash, err := s.Repo.GetUserForAuth(ctx, req.Email)
 	if err != nil {
-		return "", "", fmt.Errorf("Database Query (UserLookup): %w", err)
+		return "", "", fmt.Errorf("database query (UserLookup): %w", err)
 	}
 
 	if err := utils.CompareSecret(storedHash, req.Password); err != nil {
-		return "", "", fmt.Errorf("Secret Verification: invalid credentials")
+		return "", "", fmt.Errorf("secret verification: invalid credentials")
 	}
 
 	// 2. Client Validation
 	clientUUID, _ := uuid.Parse(req.ClientID)
 	regURI, err := s.Repo.GetClientRedirectURI(ctx, clientUUID[:])
 	if err != nil {
-		return "", "", fmt.Errorf("Database Query (ClientLookup): %w", err)
+		return "", "", fmt.Errorf("database query (ClientLookup): %w", err)
 	}
 
 	// 3. Authorization Code Logic
@@ -138,11 +141,14 @@ func (s *authService) LoginAndAuthorize(
 	userID, _ := uuid.Parse(claims.UserID)
 	err = s.Repo.StoreCode(ctx, code, userID[:], clientUUID[:], regURI)
 	if err != nil {
-		return "", "", fmt.Errorf("Database Query (StoreCode): %w", err)
+		return "", "", fmt.Errorf("database query (StoreCode): %w", err)
 	}
 
 	// 4. Session Management
 	sessionID, err := s.GetSessionToken(ctx, userID, ipAddress, userAgent)
+	if err != nil {
+		return "", "", fmt.Errorf("session token generation: %w", err)
+	}
 
 	redirectURL := fmt.Sprintf("%s?code=%s", regURI, code)
 	return redirectURL, sessionID, nil
@@ -159,13 +165,13 @@ func (s *authService) Logout(
 	// 1. Retrieve session to identify the user
 	session, err := s.SessionRepo.GetByID(ctx, sessionID)
 	if err != nil {
-		return fmt.Errorf("Database Query (GetSession): %w", err)
+		return fmt.Errorf("database query (GetSession): %w", err)
 	}
 
 	// 2. Perform global token revocation
 	err = s.Repo.RevokeTokens(ctx, session.UserId)
 	if err != nil {
-		return fmt.Errorf("Database Query (RevokeTokens): %w", err)
+		return fmt.Errorf("database query (RevokeTokens): %w", err)
 	}
 
 	// 3. Optional: Delete the session from DB
@@ -193,11 +199,11 @@ func (s *authService) ValidateSession(
 ) (*models.IdPSession, error) {
 	session, err := s.SessionRepo.GetByID(ctx, sessionID)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (GetSession): %w", err)
+		return nil, fmt.Errorf("database query (GetSession): %w", err)
 	}
 
 	if time.Now().After(session.ExpiresAt) {
-		return nil, fmt.Errorf("Session Validation: expired")
+		return nil, fmt.Errorf("session validation: expired")
 	}
 
 	return session, nil
@@ -225,45 +231,45 @@ func (s *authService) ExchangeCodeForToken(
 ) (*dto.TokenResponse, error) {
 	clientUUID, err := uuid.Parse(req.ClientID)
 	if err != nil {
-		return nil, fmt.Errorf("UUID Parse: %w", err)
+		return nil, fmt.Errorf("uuid parse: %w", err)
 	}
 	clientIDBin := clientUUID[:]
 
 	// 1. Authenticate Client
 	valid, err := s.Repo.VerifyClient(ctx, clientIDBin, req.ClientSecret)
 	if err != nil {
-		return nil, fmt.Errorf("Client Verification: %w", err)
+		return nil, fmt.Errorf("client verification: %w", err)
 	}
 	if !valid {
-		return nil, fmt.Errorf("Client Verification: invalid credentials")
+		return nil, fmt.Errorf("client verification: invalid credentials")
 	}
 
 	// 2. Consume Authorization Code
 	authCode, err := s.Repo.ExchangeCode(ctx, req.Code)
 	if err != nil {
-		return nil, fmt.Errorf("Code Exchange: %w", err)
+		return nil, fmt.Errorf("code exchange: %w", err)
 	}
 
 	// 3. Security Check: Client Mismatch
 	if !bytes.Equal(authCode.ClientId, clientIDBin) {
-		return nil, fmt.Errorf("Client Verification: id mismatch")
+		return nil, fmt.Errorf("client verification: id mismatch")
 	}
 
 	// 4. Identity Retrieval
 	claims, err := s.Repo.GetClaimsByID(ctx, authCode.UserId)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (GetClaims): %w", err)
+		return nil, fmt.Errorf("database query (GetClaims): %w", err)
 	}
 
 	client, err := s.ClientRepo.GetByID(ctx, clientIDBin)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (GetClient): %w", err)
+		return nil, fmt.Errorf("database query (GetClient): %w", err)
 	}
 
 	// 5. Token Generation
 	accessToken, err := GenerateToken(s.PrivateKey, client, *claims)
 	if err != nil {
-		return nil, fmt.Errorf("Token Generation: %w", err)
+		return nil, fmt.Errorf("token generation: %w", err)
 	}
 
 	grants, _ := s.ClientRepo.GetGrantTypes(ctx, clientIDBin)
@@ -282,7 +288,7 @@ func (s *authService) ExchangeCodeForToken(
 				clientIDBin,
 			)
 			if err != nil {
-				return nil, fmt.Errorf("Database Query (StoreRefresh): %w", err)
+				return nil, fmt.Errorf("database query (StoreRefresh): %w", err)
 			}
 		}
 	}
@@ -305,41 +311,41 @@ func (s *authService) RotateRefreshToken(
 	// 1. Identify User and Client from the existing token
 	uID, cID, err := s.Repo.GetIDsFromToken(ctx, oldToken)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (TokenLookup): %w", err)
+		return nil, fmt.Errorf("database query (TokenLookup): %w", err)
 	}
 
 	// 1.1 Verify Client Grant Type
 	grants, _ := s.ClientRepo.GetGrantTypes(ctx, cID)
 	if !slices.Contains(grants, "refresh_token") {
-		return nil, fmt.Errorf("Client Verification: missing refresh_token grant")
+		return nil, fmt.Errorf("client verification: missing refresh_token grant")
 	}
 
 	// 2. Generate and persist new Refresh Token
 	newToken, err := utils.GenerateRandomString(SECRET_ENTROPY)
 	if err != nil {
-		return nil, fmt.Errorf("Token Generation: %w", err)
+		return nil, fmt.Errorf("token generation: %w", err)
 	}
 
 	err = s.Repo.RotateRefreshToken(ctx, oldToken, newToken)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (RotateToken): %w", err)
+		return nil, fmt.Errorf("database query (RotateToken): %w", err)
 	}
 
 	// 3. Retrieve Identity and Client data
 	claims, err := s.Repo.GetClaimsByID(ctx, uID)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (GetClaims): %w", err)
+		return nil, fmt.Errorf("database query (GetClaims): %w", err)
 	}
 
 	client, err := s.ClientRepo.GetByID(ctx, cID)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (GetClient): %w", err)
+		return nil, fmt.Errorf("database query (GetClient): %w", err)
 	}
 
 	// 4. Mint new Access Token
 	accessToken, err := GenerateToken(s.PrivateKey, client, *claims)
 	if err != nil {
-		return nil, fmt.Errorf("Token Generation (JWT): %w", err)
+		return nil, fmt.Errorf("token generation (JWT): %w", err)
 	}
 
 	return &dto.TokenResponse{
@@ -361,34 +367,34 @@ func (s *authService) RefreshBySession(
 	// 1. Validate Session
 	session, err := s.SessionRepo.GetByID(ctx, sessionID)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (GetSession): %w", err)
+		return nil, fmt.Errorf("database query (GetSession): %w", err)
 	}
 
 	if time.Now().After(session.ExpiresAt) {
-		return nil, fmt.Errorf("Session Validation: expired")
+		return nil, fmt.Errorf("session validation: expired")
 	}
 
 	// 2. Validate Client
 	cUUID, err := uuid.Parse(clientIDStr)
 	if err != nil {
-		return nil, fmt.Errorf("UUID Parse: %w", err)
+		return nil, fmt.Errorf("uuid parse: %w", err)
 	}
 
 	client, err := s.ClientRepo.GetByID(ctx, cUUID[:])
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (GetClient): %w", err)
+		return nil, fmt.Errorf("database query (GetClient): %w", err)
 	}
 
 	// 3. Retrieve Identity
 	claims, err := s.Repo.GetClaimsByID(ctx, session.UserId)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (GetClaims): %w", err)
+		return nil, fmt.Errorf("database query (GetClaims): %w", err)
 	}
 
 	// 4. Mint new Access Token
 	accessToken, err := GenerateToken(s.PrivateKey, client, *claims)
 	if err != nil {
-		return nil, fmt.Errorf("Token Generation (JWT): %w", err)
+		return nil, fmt.Errorf("token generation (JWT): %w", err)
 	}
 
 	return &dto.TokenResponse{
@@ -417,7 +423,7 @@ func (s *authService) GetSessionToken(ctx context.Context,
 	}
 
 	if err := s.SessionRepo.Create(ctx, session); err != nil {
-		return "", fmt.Errorf("Database Query (CreateSession): %w", err)
+		return "", fmt.Errorf("database query (CreateSession): %w", err)
 	}
 
 	return sessionID, nil

--- a/backend/internal/service/client_service.go
+++ b/backend/internal/service/client_service.go
@@ -71,7 +71,7 @@ func (s *clientService) CreateClient(
 		s.Storage,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("Storage Upload: %w", err)
+		return nil, fmt.Errorf("storage upload: %w", err)
 	}
 
 	// 2. Security & ID Generation
@@ -94,7 +94,7 @@ func (s *clientService) CreateClient(
 	// 4. Persistence
 	err = s.Repo.CreateClient(ctx, clientModel, req.Grants, userID[:])
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (Create): %w", err)
+		return nil, fmt.Errorf("database query (Create): %w", err)
 	}
 
 	return &dto.ClientSecretResponse{
@@ -124,7 +124,7 @@ func (s *clientService) GetFilteredClientList(
 		return s.GetBoundClients(ctx, userID, limit, page, keyword)
 	}
 
-	return nil, fmt.Errorf("Privilege Validation: restricted level")
+	return nil, fmt.Errorf("privilege validation: restricted level")
 }
 
 func (s *clientService) checkClientAccess(
@@ -142,10 +142,10 @@ func (s *clientService) checkClientAccess(
 	if slices.Contains(permissions, "View connected appclients") {
 		allowed, err := s.Repo.IsClientAllowed(ctx, userID[:], clientID[:])
 		if err != nil {
-			return fmt.Errorf("Repository Check: %w", err)
+			return fmt.Errorf("repository check: %w", err)
 		}
 		if !allowed {
-			return fmt.Errorf("Authorization: client is outside of your scope")
+			return fmt.Errorf("authorization: client is outside of your scope")
 		}
 		return nil
 	}
@@ -168,12 +168,12 @@ func (s *clientService) GetClientList(
 
 	total, err := s.Repo.CountClients(ctx, keyword)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (Count): %w", err)
+		return nil, fmt.Errorf("database query (Count): %w", err)
 	}
 
 	clients, err := s.Repo.ListClients(ctx, limit, offset, keyword)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (List): %w", err)
+		return nil, fmt.Errorf("database query (List): %w", err)
 	}
 
 	var res []dto.ClientResponse
@@ -236,12 +236,12 @@ func (s *clientService) GetBoundClients(
 		userID[:],
 	)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (ListBound): %w", err)
+		return nil, fmt.Errorf("database query (ListBound): %w", err)
 	}
 
 	total, err := s.Repo.CountBoundClients(ctx, keyword, userID[:])
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (CountBound): %v", err)
+		return nil, fmt.Errorf("database query (CountBound): %v", err)
 	}
 
 	var res []dto.ClientResponse
@@ -284,14 +284,14 @@ func (s *clientService) GetClientByID(
 
 	cl, err := s.Repo.GetByID(ctx, id[:])
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (GetByID): %w", err)
+		return nil, fmt.Errorf("database query (GetByID): %w", err)
 	}
 
 	// Fetch associated data
 	grants, _ := s.Repo.GetGrantTypes(ctx, cl.ID)
 	roles, err := s.Repo.GetClientAllowedRoles(ctx, cl.ID)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (GetRoles): %w", err)
+		return nil, fmt.Errorf("database query (GetRoles): %w", err)
 	}
 
 	// Process image
@@ -345,7 +345,7 @@ func (s *clientService) UpdateClient(
 
 	existing, err := s.Repo.GetByID(ctx, id[:])
 	if err != nil {
-		return fmt.Errorf("Database Query (Search): %w", err)
+		return fmt.Errorf("database query (Search): %w", err)
 	}
 
 	imagePath := existing.ImageLocation
@@ -358,7 +358,7 @@ func (s *clientService) UpdateClient(
 			s.Storage,
 		)
 		if err != nil {
-			return fmt.Errorf("Storage Upload: %w", err)
+			return fmt.Errorf("storage upload: %w", err)
 		}
 		imagePath = newPath
 	}
@@ -375,7 +375,7 @@ func (s *clientService) UpdateClient(
 
 	err = s.Repo.UpdateClient(ctx, clientModel, req.Grants)
 	if err != nil {
-		return fmt.Errorf("Database Query (Update): %w", err)
+		return fmt.Errorf("database query (Update): %w", err)
 	}
 
 	return nil
@@ -398,19 +398,19 @@ func (s *clientService) RotateClientSecret(
 	// 1. Generate High-Entropy Secret
 	newSecret, err := utils.GenerateRandomString(SECRET_ENTROPY)
 	if err != nil {
-		return nil, fmt.Errorf("Secret Generation: %w", err)
+		return nil, fmt.Errorf("secret generation: %w", err)
 	}
 
 	// 2. Secure Hashing
 	newSecretHash, err := utils.HashSecret(newSecret)
 	if err != nil {
-		return nil, fmt.Errorf("Secret Hashing: %w", err)
+		return nil, fmt.Errorf("secret hashing: %w", err)
 	}
 
 	// 3. Persistence
 	err = s.Repo.ChangeSecret(ctx, id[:], newSecretHash)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (ChangeSecret): %w", err)
+		return nil, fmt.Errorf("database query (ChangeSecret): %w", err)
 	}
 
 	return &dto.ClientSecretResponse{
@@ -436,18 +436,18 @@ func (s *clientService) DeleteClient(
 
 	cl, err := s.Repo.GetByID(ctx, id[:])
 	if err != nil {
-		return fmt.Errorf("Database Query (Search): %w", err)
+		return fmt.Errorf("database query (Search): %w", err)
 	}
 
 	// 1. Cleanup Cloud Storage
 	err = DeleteImage(ctx, cl.ImageLocation, s.Storage)
 	if err != nil {
-		return fmt.Errorf("Storage Delete: %w", err)
+		return fmt.Errorf("storage delete: %w", err)
 	}
 
 	// 2. Soft Delete Client Record
 	if err := s.Repo.SoftDelete(ctx, id[:]); err != nil {
-		return fmt.Errorf("Database Query (SoftDelete): %w", err)
+		return fmt.Errorf("database query (SoftDelete): %w", err)
 	}
 
 	return nil

--- a/backend/internal/service/role_service.go
+++ b/backend/internal/service/role_service.go
@@ -54,7 +54,7 @@ func (s *roleService) CreateRole(
 
 	_, err := s.RoleRepo.CreateRole(ctx, role)
 	if err != nil {
-		return fmt.Errorf("Database Query (CreateRole): %w", err)
+		return fmt.Errorf("database query (CreateRole): %w", err)
 	}
 
 	return nil
@@ -75,7 +75,7 @@ func (s *roleService) GetFilteredRoleList(
 		return s.GetRoleList(ctx, limit, page, keyword)
 	}
 
-	return nil, fmt.Errorf("Privilege Validation: level unauthorized")
+	return nil, fmt.Errorf("privilege validation: level unauthorized")
 }
 
 /**
@@ -91,12 +91,12 @@ func (s *roleService) GetRoleList(
 
 	roles, err := s.RoleRepo.ListRoles(ctx, limit, offset, keyword)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (ListRoles): %w", err)
+		return nil, fmt.Errorf("database query (ListRoles): %w", err)
 	}
 
 	total, err := s.RoleRepo.CountRoles(ctx, keyword)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (CountRoles): %w", err)
+		return nil, fmt.Errorf("database query (CountRoles): %w", err)
 	}
 
 	return s.formatRoleListResponse(roles, total, limit, page), nil
@@ -115,12 +115,12 @@ func (s *roleService) GetAllExceptIDP(
 
 	roles, err := s.RoleRepo.ListAllExceptIdP(ctx, limit, offset, keyword)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (ListRoles): %w", err)
+		return nil, fmt.Errorf("database query (ListRoles): %w", err)
 	}
 
 	total, err := s.RoleRepo.CountRoles(ctx, keyword)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (CountRoles): %w", err)
+		return nil, fmt.Errorf("database query (CountRoles): %w", err)
 	}
 
 	return s.formatRoleListResponse(roles, total, limit, page), nil
@@ -146,12 +146,12 @@ func (s *roleService) GetAuthorizedRoles(
 		keyword,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (ListBoundRoles): %w", err)
+		return nil, fmt.Errorf("database query (ListBoundRoles): %w", err)
 	}
 
 	total, err := s.RoleRepo.CountDistinctBoundRoles(ctx, userID[:], keyword)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (CountBoundRoles): %w", err)
+		return nil, fmt.Errorf("database query (CountBoundRoles): %w", err)
 	}
 
 	return s.formatRoleWithMetadataListResponse(roles, total, limit, page), nil
@@ -235,7 +235,7 @@ func (s *roleService) GetRoleByID(
 ) (*dto.RoleResponse, error) {
 	role, err := s.RoleRepo.GetByID(ctx, id)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (GetByID): %w", err)
+		return nil, fmt.Errorf("database query (GetByID): %w", err)
 	}
 
 	return &dto.RoleResponse{
@@ -257,11 +257,11 @@ func (s *roleService) SearchRoles(
 ) (*dto.RoleListResponse, error) {
 	roles, err := s.RoleRepo.SearchRoles(ctx, keyword)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (SearchRoles): %w", err)
+		return nil, fmt.Errorf("database query (SearchRoles): %w", err)
 	}
 
 	if len(roles) == 0 {
-		return nil, fmt.Errorf("Database Query (SearchRoles): no records")
+		return nil, fmt.Errorf("database query (SearchRoles): no records")
 	}
 
 	var roleResponses []dto.RoleResponse
@@ -308,7 +308,7 @@ func (s *roleService) UpdateRole(
 	}
 
 	if err := s.RoleRepo.UpdateRole(ctx, role); err != nil {
-		return fmt.Errorf("Database Query (UpdateRole): %w", err)
+		return fmt.Errorf("database query (UpdateRole): %w", err)
 	}
 
 	return nil
@@ -319,7 +319,7 @@ func (s *roleService) UpdateRole(
  */
 func (s *roleService) DeleteRole(ctx context.Context, id int) error {
 	if err := s.RoleRepo.Delete(ctx, id); err != nil {
-		return fmt.Errorf("Database Query (Delete): %w", err)
+		return fmt.Errorf("database query (Delete): %w", err)
 	}
 
 	return nil

--- a/backend/internal/service/token_service.go
+++ b/backend/internal/service/token_service.go
@@ -21,7 +21,7 @@ func GenerateToken(privateKey *rsa.PrivateKey,
 
 	clientIDStr, err := uuid.FromBytes(client.ID)
 	if err != nil {
-		return "", fmt.Errorf("Failed to get uuid from client bytes: %v", err)
+		return "", fmt.Errorf("failed to get uuid from client bytes: %v", err)
 	}
 
 	claims.AuthorizedParty = clientIDStr.String()

--- a/backend/internal/service/user_service.go
+++ b/backend/internal/service/user_service.go
@@ -75,7 +75,7 @@ func (s *userService) CreateUser(
 
 	passwordHash, err := utils.HashSecret(req.Password)
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("Secret Hashing: %w", err)
+		return uuid.Nil, fmt.Errorf("secret hashing: %w", err)
 	}
 
 	user := models.User{
@@ -97,18 +97,18 @@ func (s *userService) CreateUser(
 
 	err = s.Repo.CreateUser(ctx, &user)
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("Database Query (CreateUser): %w", err)
+		return uuid.Nil, fmt.Errorf("database query (CreateUser): %w", err)
 	}
 
 	if req.AccountType != "" {
 		typeID, err := s.RegRepo.GetAccountTypeIDByName(ctx, req.AccountType)
 		if err != nil {
-			return userID, fmt.Errorf("Post-Create (TypeLookup): %w", err)
+			return userID, fmt.Errorf("post-create (TypeLookup): %w", err)
 		}
 
 		clients, err := s.RegRepo.GetClientsByAccountTypeID(ctx, typeID)
 		if err != nil {
-			return userID, fmt.Errorf("Post-Create (RegFetch): %w", err)
+			return userID, fmt.Errorf("post-create (RegFetch): %w", err)
 		}
 
 		if len(clients) > 0 {
@@ -118,7 +118,7 @@ func (s *userService) CreateUser(
 			}
 			err = s.CAURepo.BatchAssignClientAccess(ctx, user.ID, clientIDs)
 			if err != nil {
-				return userID, fmt.Errorf("Post-Create (Assign): %w", err)
+				return userID, fmt.Errorf("post-create (Assign): %w", err)
 			}
 		}
 	}
@@ -128,13 +128,13 @@ func (s *userService) CreateUser(
 		for _, clientIDStr := range req.AllowedAppClients {
 			cid, err := uuid.Parse(clientIDStr)
 			if err != nil {
-				return userID, fmt.Errorf("Post-Create (UUID): %w", err)
+				return userID, fmt.Errorf("post-create (UUID): %w", err)
 			}
 			clientIDs = append(clientIDs, cid[:])
 		}
 		err = s.ClientRepo.BatchAdminClientBind(ctx, user.ID, clientIDs)
 		if err != nil {
-			return userID, fmt.Errorf("Post-Create (AdminBind): %w", err)
+			return userID, fmt.Errorf("post-create (AdminBind): %w", err)
 		}
 	}
 
@@ -152,7 +152,7 @@ func (s *userService) CreateAdminUser(
 
 	passwordHash, err := utils.HashSecret(req.Password)
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("Secret Hashing: %w", err)
+		return uuid.Nil, fmt.Errorf("secret hashing: %w", err)
 	}
 
 	user := models.User{
@@ -174,14 +174,14 @@ func (s *userService) CreateAdminUser(
 
 	err = s.Repo.CreateUser(ctx, &user)
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("Database Query (CreateAdminUser): %w", err)
+		return uuid.Nil, fmt.Errorf("database query (CreateAdminUser): %w", err)
 	}
 
 	if req.AccountTypeID != 0 {
 		clients, err := s.RegRepo.GetClientsByAccountTypeID(ctx,
 			req.AccountTypeID)
 		if err != nil {
-			return userID, fmt.Errorf("Post-Create (RegFetch): %w", err)
+			return userID, fmt.Errorf("post-create (RegFetch): %w", err)
 		}
 
 		if len(clients) > 0 {
@@ -191,7 +191,7 @@ func (s *userService) CreateAdminUser(
 			}
 			err = s.CAURepo.BatchAssignClientAccess(ctx, user.ID, clientIDs)
 			if err != nil {
-				return userID, fmt.Errorf("Post-Create (Assign): %w", err)
+				return userID, fmt.Errorf("post-create (Assign): %w", err)
 			}
 		}
 	}
@@ -201,13 +201,13 @@ func (s *userService) CreateAdminUser(
 		for _, clientIDStr := range req.AllowedAppClients {
 			cid, err := uuid.Parse(clientIDStr)
 			if err != nil {
-				return userID, fmt.Errorf("Post-Create (UUID): %w", err)
+				return userID, fmt.Errorf("post-create (UUID): %w", err)
 			}
 			clientIDs = append(clientIDs, cid[:])
 		}
 		err = s.ClientRepo.BatchAdminClientBind(ctx, user.ID, clientIDs)
 		if err != nil {
-			return userID, fmt.Errorf("Post-Create (AdminBind): %w", err)
+			return userID, fmt.Errorf("post-create (AdminBind): %w", err)
 		}
 	}
 
@@ -223,7 +223,7 @@ func (s *userService) GetUserByID(
 ) (*dto.UserResponse, error) {
 	user, err := s.Repo.GetUserById(ctx, id[:])
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (GetUserById): %w", err)
+		return nil, fmt.Errorf("database query (GetUserById): %w", err)
 	}
 
 	if user == nil {
@@ -241,7 +241,7 @@ func (s *userService) GetMe(
 ) (*dto.UserInfoResponse, error) {
 	user, err := s.Repo.GetUserById(ctx, userID[:])
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (GetUser): %w", err)
+		return nil, fmt.Errorf("database query (GetUser): %w", err)
 	}
 
 	return &dto.UserInfoResponse{
@@ -273,7 +273,7 @@ func (s *userService) GetFilteredUserList(
 	} else if slices.Contains(permissions, "View users based on appclient") {
 		resp, err = s.GetBoundUserList(ctx, limit, page, userID)
 	} else {
-		return nil, fmt.Errorf("Privilege Validation: unauthorized level")
+		return nil, fmt.Errorf("privilege validation: unauthorized level")
 	}
 
 	if err != nil {
@@ -295,12 +295,12 @@ func (s *userService) GetUserList(
 
 	users, err := s.Repo.GetUserList(ctx, limit, offset)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (GetUserList): %w", err)
+		return nil, fmt.Errorf("database query (GetUserList): %w", err)
 	}
 
 	total, err := s.Repo.CountUsers(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (CountUsers): %w", err)
+		return nil, fmt.Errorf("database query (CountUsers): %w", err)
 	}
 
 	var userResponses []dto.UserSimplifiedResponse
@@ -336,12 +336,12 @@ func (s *userService) GetBoundUserList(
 
 	users, err := s.Repo.GetBoundUserList(ctx, limit, offset, userID[:])
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (GetBound): %w", err)
+		return nil, fmt.Errorf("database query (GetBound): %w", err)
 	}
 
 	total, err := s.Repo.CountBoundUsers(ctx, userID[:])
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (CountBound): %w", err)
+		return nil, fmt.Errorf("database query (CountBound): %w", err)
 	}
 
 	var userResponses []dto.UserSimplifiedResponse
@@ -374,7 +374,7 @@ func (s *userService) UpdateUserPassword(
 ) error {
 	passwordHash, err := utils.HashSecret(newPassword)
 	if err != nil {
-		return fmt.Errorf("Secret Hashing: %w", err)
+		return fmt.Errorf("secret hashing: %w", err)
 	}
 
 	user := models.User{
@@ -384,7 +384,7 @@ func (s *userService) UpdateUserPassword(
 
 	err = s.Repo.UpdateUserPassword(ctx, &user)
 	if err != nil {
-		return fmt.Errorf("Database Query (UpdatePassword): %w", err)
+		return fmt.Errorf("database query (UpdatePassword): %w", err)
 	}
 
 	return nil
@@ -400,7 +400,7 @@ func (s *userService) UpdateUserPasswordByEmail(
 ) error {
 	user, err := s.Repo.GetUserByEmail(ctx, email)
 	if err != nil {
-		return fmt.Errorf("Database Query (GetUserByEmail): %w", err)
+		return fmt.Errorf("database query (GetUserByEmail): %w", err)
 	}
 	if user == nil {
 		return fmt.Errorf("user not found")
@@ -420,7 +420,7 @@ func (s *userService) UpdateUserStatus(
 ) error {
 	status, err := models.MapStatus(newStatus)
 	if err != nil {
-		return fmt.Errorf("Status Validation: %w", err)
+		return fmt.Errorf("status validation: %w", err)
 	}
 
 	user := models.User{
@@ -430,7 +430,7 @@ func (s *userService) UpdateUserStatus(
 
 	err = s.Repo.UpdateStatus(ctx, &user)
 	if err != nil {
-		return fmt.Errorf("Database Query (UpdateStatus): %w", err)
+		return fmt.Errorf("database query (UpdateStatus): %w", err)
 	}
 
 	return nil
@@ -457,12 +457,12 @@ func (s *userService) UpdateUserRole(
 		}
 		err := s.Repo.UpdateUserRole(ctx, id[:], nullRoleID)
 		if err != nil {
-			return fmt.Errorf("Database Query (UpdateUserRole): %w", err)
+			return fmt.Errorf("database query (UpdateUserRole): %w", err)
 		}
 		return nil
 	}
 
-	return fmt.Errorf("Permission Validation: unauthorized to update roles")
+	return fmt.Errorf("permission validation: unauthorized to update roles")
 }
 
 /**
@@ -483,7 +483,7 @@ func (s *userService) UpdateUserName(
 
 	err := s.Repo.UpdateUserName(ctx, &user)
 	if err != nil {
-		return fmt.Errorf("Database Query (UpdateUserName): %w", err)
+		return fmt.Errorf("database query (UpdateUserName): %w", err)
 	}
 
 	return nil
@@ -501,19 +501,19 @@ func (s *userService) ChangePassword(
 	// 1. Get user to retrieve email
 	user, err := s.Repo.GetUserById(ctx, id[:])
 	if err != nil || user == nil {
-		return fmt.Errorf("User Identification: not found")
+		return fmt.Errorf("user identification: not found")
 	}
 
 	// 2. Get user data with hash using email
 	userData, err := s.Repo.GetUserByEmail(ctx, user.Email)
 	if err != nil || userData == nil {
-		return fmt.Errorf("User Verification: lookup failed")
+		return fmt.Errorf("user verification: lookup failed")
 	}
 
 	// 3. Compare old password
 	err = utils.CompareSecret(userData.PasswordHash, oldPassword)
 	if err != nil {
-		return fmt.Errorf("User Verification: invalid credentials")
+		return fmt.Errorf("user verification: invalid credentials")
 	}
 
 	// 4. Update with new password
@@ -522,7 +522,7 @@ func (s *userService) ChangePassword(
 
 func (s *userService) DeleteUser(ctx context.Context, id uuid.UUID) error {
 	if err := s.Repo.SoftDelete(ctx, id[:]); err != nil {
-		return fmt.Errorf("Database Query (SoftDelete): %w", err)
+		return fmt.Errorf("database query (SoftDelete): %w", err)
 	}
 
 	return nil
@@ -605,12 +605,12 @@ func (s *userService) GetAdminUserList(
 
 	users, err := s.Repo.GetAdminUserList(ctx, limit, offset)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (GetAdminList): %w", err)
+		return nil, fmt.Errorf("database query (GetAdminList): %w", err)
 	}
 
 	total, err := s.Repo.CountAdminUsers(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("Database Query (CountAdmins): %w", err)
+		return nil, fmt.Errorf("database query (CountAdmins): %w", err)
 	}
 
 	var userResponses []dto.UserResponse


### PR DESCRIPTION
This pull request standardizes and improves the clarity of error messages throughout the backend codebase. The main change is the consistent use of lowercase error messages and more descriptive, context-aware phrasing, which will help with debugging and log readability.

**Error message consistency and clarity:**

* Changed all error messages to use lowercase and more natural phrasing, making them easier to read and more consistent across the codebase. This affects error handling in database connections, user authentication, client management, and repository operations. [[1]](diffhunk://#diff-6b8e9f50b5fc06b2a265a5624381b7670734c45a0004fbe20b7f2019af91a083L28-R28) [[2]](diffhunk://#diff-6b8e9f50b5fc06b2a265a5624381b7670734c45a0004fbe20b7f2019af91a083L49-R49) [[3]](diffhunk://#diff-6b8e9f50b5fc06b2a265a5624381b7670734c45a0004fbe20b7f2019af91a083L63-R63) [[4]](diffhunk://#diff-0de3eebffb218e14a07156b21f22a8716d535de652bca135efe25cd772a79b94L42-R42) [[5]](diffhunk://#diff-78c47bf3d9343e47063d15a0c563d68fcba799efbfb0a0153e617bf1f751fe43L72-R76) [[6]](diffhunk://#diff-78c47bf3d9343e47063d15a0c563d68fcba799efbfb0a0153e617bf1f751fe43L86-R91) [[7]](diffhunk://#diff-78c47bf3d9343e47063d15a0c563d68fcba799efbfb0a0153e617bf1f751fe43L106-R106) [[8]](diffhunk://#diff-808cc06c4131521a49e0b5a98a43f4055733ff4f7d4292072cf4f47e1d1a09c6L242-R242) [[9]](diffhunk://#diff-6ce0e7a1a9334fdb903d18528dc77bbd0c874cf00478d3b4e9bad797fcb2fd3bL505-R505) [[10]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaL74-R106) [[11]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaL122-R151) [[12]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaL162-R174) [[13]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaL196-R206) [[14]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaL228-R272) [[15]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaL285-R291) [[16]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaL308-R348) [[17]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaL364-R397) [[18]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaL420-R426) [[19]](diffhunk://#diff-3b1cf9ca5e67f8cb81f7c3defe38213961a12c17b2c7186153b4c95a907b4902L74-R74) [[20]](diffhunk://#diff-3b1cf9ca5e67f8cb81f7c3defe38213961a12c17b2c7186153b4c95a907b4902L97-R97) [[21]](diffhunk://#diff-3b1cf9ca5e67f8cb81f7c3defe38213961a12c17b2c7186153b4c95a907b4902L127-R127) [[22]](diffhunk://#diff-3b1cf9ca5e67f8cb81f7c3defe38213961a12c17b2c7186153b4c95a907b4902L145-R148) [[23]](diffhunk://#diff-3b1cf9ca5e67f8cb81f7c3defe38213961a12c17b2c7186153b4c95a907b4902L171-R176) [[24]](diffhunk://#diff-3b1cf9ca5e67f8cb81f7c3defe38213961a12c17b2c7186153b4c95a907b4902L239-R244) [[25]](diffhunk://#diff-3b1cf9ca5e67f8cb81f7c3defe38213961a12c17b2c7186153b4c95a907b4902L287-R294) [[26]](diffhunk://#diff-3b1cf9ca5e67f8cb81f7c3defe38213961a12c17b2c7186153b4c95a907b4902L348-R348) [[27]](diffhunk://#diff-3b1cf9ca5e67f8cb81f7c3defe38213961a12c17b2c7186153b4c95a907b4902L361-R361)

**Authentication and authorization services:**

* Improved error messages in authentication flows, including user login, session validation, authorization code exchange, refresh token rotation, and session-based refresh. These changes make it clearer where failures occur (e.g., "uuid parse", "code generation", "database query (GetSession)"). [[1]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaL74-R106) [[2]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaL122-R151) [[3]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaL162-R174) [[4]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaL196-R206) [[5]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaL228-R272) [[6]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaL285-R291) [[7]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaL308-R348) [[8]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaL364-R397) [[9]](diffhunk://#diff-05c8ed1c730feb9ce0bba84c1f888d9e3dfec4039c092f32d0c69125a8e9a5eaL420-R426)

**Client service and repository:**

* Standardized error messages for client creation, retrieval, update, and access checking, improving the consistency and traceability of client-related errors. [[1]](diffhunk://#diff-3b1cf9ca5e67f8cb81f7c3defe38213961a12c17b2c7186153b4c95a907b4902L74-R74) [[2]](diffhunk://#diff-3b1cf9ca5e67f8cb81f7c3defe38213961a12c17b2c7186153b4c95a907b4902L97-R97) [[3]](diffhunk://#diff-3b1cf9ca5e67f8cb81f7c3defe38213961a12c17b2c7186153b4c95a907b4902L127-R127) [[4]](diffhunk://#diff-3b1cf9ca5e67f8cb81f7c3defe38213961a12c17b2c7186153b4c95a907b4902L145-R148) [[5]](diffhunk://#diff-3b1cf9ca5e67f8cb81f7c3defe38213961a12c17b2c7186153b4c95a907b4902L171-R176) [[6]](diffhunk://#diff-3b1cf9ca5e67f8cb81f7c3defe38213961a12c17b2c7186153b4c95a907b4902L239-R244) [[7]](diffhunk://#diff-3b1cf9ca5e67f8cb81f7c3defe38213961a12c17b2c7186153b4c95a907b4902L287-R294) [[8]](diffhunk://#diff-3b1cf9ca5e67f8cb81f7c3defe38213961a12c17b2c7186153b4c95a907b4902L348-R348) [[9]](diffhunk://#diff-3b1cf9ca5e67f8cb81f7c3defe38213961a12c17b2c7186153b4c95a907b4902L361-R361)

**Repository and database connection:**

* Updated error messages in repository methods and database connection functions to be more descriptive and consistent, aiding troubleshooting and maintenance. [[1]](diffhunk://#diff-6b8e9f50b5fc06b2a265a5624381b7670734c45a0004fbe20b7f2019af91a083L28-R28) [[2]](diffhunk://#diff-6b8e9f50b5fc06b2a265a5624381b7670734c45a0004fbe20b7f2019af91a083L49-R49) [[3]](diffhunk://#diff-6b8e9f50b5fc06b2a265a5624381b7670734c45a0004fbe20b7f2019af91a083L63-R63) [[4]](diffhunk://#diff-78c47bf3d9343e47063d15a0c563d68fcba799efbfb0a0153e617bf1f751fe43L72-R76) [[5]](diffhunk://#diff-78c47bf3d9343e47063d15a0c563d68fcba799efbfb0a0153e617bf1f751fe43L86-R91) [[6]](diffhunk://#diff-78c47bf3d9343e47063d15a0c563d68fcba799efbfb0a0153e617bf1f751fe43L106-R106) [[7]](diffhunk://#diff-808cc06c4131521a49e0b5a98a43f4055733ff4f7d4292072cf4f47e1d1a09c6L242-R242) [[8]](diffhunk://#diff-6ce0e7a1a9334fdb903d18528dc77bbd0c874cf00478d3b4e9bad797fcb2fd3bL505-R505)

**User model and status mapping:**

* Adjusted error message in `MapStatus` to use lowercase and clearer wording for invalid status strings.