### PR TITLE
update image path

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -83,14 +83,14 @@ jobs:
         with:
           context: ./backend
           push: true
-          tags: ghcr.io/iskolutions/idp-backend:latest
+          tags: ghcr.io/iskolutions-capstone-dev-team/idp-backend:latest
 
       - name: Build and Push Frontend
         uses: docker/build-push-action@v5
         with:
           context: ./frontend
           push: true
-          tags: ghcr.io/iskolutions/idp-frontend:latest
+          tags: ghcr.io/iskolutions-capstone-dev-team/idp-frontend:latest
 
   deploy-staging:
     if: github.event_name == 'push' && github.ref == 'refs/heads/development'


### PR DESCRIPTION
This pull request updates the Docker image repository paths in the CI/CD workflow to use the new organization name. The change ensures that both backend and frontend images are pushed to the correct container registry under the `iskolutions-capstone-dev-team` namespace.

CI/CD pipeline updates:

* Updated the Docker image tags for both backend and frontend in `.github/workflows/ci-cd.yml` to use `ghcr.io/iskolutions-capstone-dev-team` instead of `ghcr.io/iskolutions`.