### PR TITLE
chore(ci): align registry paths and remove .env generation in workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -116,9 +116,8 @@ jobs:
           username: ${{ secrets.STAGING_USER }}
           key: ${{ secrets.STAGING_SSH_PK }}
           script: |
-            cd ~/Identity-Provider
+            cd Identity-Provider/
             git pull origin development
-            echo "${{ secrets.STAGING_ENV }}" > .env
             echo "${{ secrets.GH_PAT }}" | \
               docker login ghcr.io -u ${{ secrets.GH_USERNAME }} \
               --password-stdin
@@ -149,9 +148,8 @@ jobs:
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            cd ~/Identity-Provider
+            cd Identity-Provider/
             git pull origin main
-            echo "${{ secrets.ENV_FILE }}" > .env
             echo "${{ secrets.GH_PAT }}" | \
               docker login ghcr.io -u ${{ secrets.GH_USERNAME }} \
               --password-stdin

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -1,7 +1,7 @@
 services:
   # Identity Provider Backend (GHCR Image)
   backend:
-    image: ghcr.io/iskolutions/idp-backend:latest
+    image: ghcr.io/iskolutions-capstone-dev-team/idp-backend:latest
     container_name: idp_backend
     restart: always
     env_file: ./.env
@@ -24,7 +24,7 @@ services:
 
   # Identity Provider Frontend (GHCR Image)
   frontend:
-    image: ghcr.io/iskolutions/idp-frontend:latest
+    image: ghcr.io/iskolutions-capstone-dev-team/idp-frontend:latest
     container_name: idp_frontend
     restart: always
     environment:


### PR DESCRIPTION
This pull request updates deployment and configuration settings to align with new repository and image naming conventions. It also simplifies the deployment scripts by adjusting directory navigation and removing redundant environment file commands.

**Deployment configuration updates:**

* Updated the Docker image references for both backend and frontend services in `docker-compose.ghcr.yml` to use the new `ghcr.io/iskolutions-capstone-dev-team/` namespace. [[1]](diffhunk://#diff-853304662c013625dcbd238912cdcc9d9d42985f4e95924ae7fcc81fe43c83c0L4-R4) [[2]](diffhunk://#diff-853304662c013625dcbd238912cdcc9d9d42985f4e95924ae7fcc81fe43c83c0L27-R27)

**CI/CD workflow improvements:**

* Changed the deployment script paths in `.github/workflows/ci-cd.yml` to use `cd Identity-Provider/` instead of referencing the home directory, ensuring consistency across environments. [[1]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L119-L121) [[2]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L152-L154)
* Removed redundant commands that wrote environment variables to `.env` files during deployment, as these are now handled elsewhere. [[1]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L119-L121) [[2]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L152-L154)