### PR TITLE
Fix/userpool

### DIFF
--- a/frontend/src/hooks/useAllAppClients.js
+++ b/frontend/src/hooks/useAllAppClients.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { clientService } from "../services/clientService";
 
 const ITEMS_PER_PAGE = 50;
+let allAppClientsRequest = null;
 
 const normalizeRoleNames = (roles = []) =>
   Array.from(
@@ -27,6 +28,67 @@ const mapClientSummary = (client = {}) => {
   };
 };
 
+async function getAllAppClientOptions() {
+  const firstPage = await clientService.getClients({
+    limit: ITEMS_PER_PAGE,
+    page: 1,
+  });
+  const collectedClients = Array.isArray(firstPage?.items)
+    ? [...firstPage.items]
+    : [];
+  const lastPage =
+    Number.isInteger(firstPage?.lastPage) && firstPage.lastPage > 1
+      ? firstPage.lastPage
+      : 1;
+
+  if (lastPage > 1) {
+    const pageRequests = [];
+
+    for (let page = 2; page <= lastPage; page += 1) {
+      pageRequests.push(
+        clientService.getClients({
+          limit: ITEMS_PER_PAGE,
+          page,
+        }),
+      );
+    }
+
+    const pageResults = await Promise.all(pageRequests);
+    pageResults.forEach((pagePayload) => {
+      if (Array.isArray(pagePayload?.items)) {
+        collectedClients.push(...pagePayload.items);
+      }
+    });
+  }
+
+  const clientMap = new Map();
+  collectedClients.forEach((client) => {
+    const normalizedClient = mapClientSummary(client);
+
+    if (!normalizedClient.id || !normalizedClient.name) {
+      return;
+    }
+
+    clientMap.set(normalizedClient.id, normalizedClient);
+  });
+
+  return Array.from(clientMap.values()).sort((firstClient, secondClient) =>
+    firstClient.name.localeCompare(secondClient.name),
+  );
+}
+
+function loadAllAppClientOptions() {
+  if (allAppClientsRequest) {
+    return allAppClientsRequest;
+  }
+
+  allAppClientsRequest = getAllAppClientOptions().finally(() => {
+    allAppClientsRequest = null;
+  });
+
+  return allAppClientsRequest;
+}
+
 export function useAllAppClients({ enabled = true } = {}) {
   const [appClients, setAppClients] = useState([]);
   const [isLoadingAppClients, setIsLoadingAppClients] = useState(enabled);
@@ -47,78 +109,10 @@ export function useAllAppClients({ enabled = true } = {}) {
         setIsLoadingAppClients(true);
         setAppClientsError("");
 
-        const firstPage = await clientService.getClients({
-          limit: ITEMS_PER_PAGE,
-          page: 1,
-        });
-        const collectedClients = Array.isArray(firstPage?.items)
-          ? [...firstPage.items]
-          : [];
-        const lastPage =
-          Number.isInteger(firstPage?.lastPage) && firstPage.lastPage > 1
-            ? firstPage.lastPage
-            : 1;
-
-        if (lastPage > 1) {
-          const pageRequests = [];
-
-          for (let page = 2; page <= lastPage; page += 1) {
-            pageRequests.push(
-              clientService.getClients({
-                limit: ITEMS_PER_PAGE,
-                page,
-              }),
-            );
-          }
-
-          const pageResults = await Promise.all(pageRequests);
-          pageResults.forEach((pagePayload) => {
-            if (Array.isArray(pagePayload?.items)) {
-              collectedClients.push(...pagePayload.items);
-            }
-          });
-        }
-
-        const uniqueClientIds = Array.from(
-          new Set(
-            collectedClients
-              .map((client) => client?.id ?? client?.client_id ?? client?.clientId ?? "")
-              .filter(Boolean),
-          ),
-        );
-        const detailedClients = await Promise.all(
-          uniqueClientIds.map(async (clientId) => {
-            try {
-              const clientDetail = await clientService.getClientById(clientId);
-              return mapClientSummary(clientDetail?.client ?? clientDetail);
-            } catch (error) {
-              console.error(`Failed to fetch app client details for ${clientId}:`, error);
-              const matchedClient = collectedClients.find((client) => {
-                const currentClientId =
-                  client?.id ?? client?.client_id ?? client?.clientId ?? "";
-
-                return currentClientId === clientId;
-              });
-
-              return mapClientSummary(matchedClient);
-            }
-          }),
-        );
-        const clientMap = new Map();
-        detailedClients.forEach((client) => {
-          if (!client?.id) {
-            return;
-          }
-
-          clientMap.set(client.id, client);
-        });
+        const nextAppClients = await loadAllAppClientOptions();
 
         if (!cancelled) {
-          setAppClients(
-            Array.from(clientMap.values()).sort((firstClient, secondClient) =>
-              firstClient.name.localeCompare(secondClient.name),
-            ),
-          );
+          setAppClients(nextAppClients);
         }
       } catch (error) {
         console.error("Failed to fetch app clients:", error);

--- a/frontend/src/hooks/useManagedUserAccessClients.js
+++ b/frontend/src/hooks/useManagedUserAccessClients.js
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import { userService } from "../services/userService";
 
+let managedUserAccessClientsRequest = null;
+
 function mapManagedClient(client = {}) {
   const id = client?.id ?? client?.client_id ?? client?.clientId ?? "";
   const name = client?.name ?? client?.client_name ?? client?.clientName ?? "";
@@ -9,6 +11,19 @@ function mapManagedClient(client = {}) {
     id,
     name: typeof name === "string" ? name.trim() : "",
   };
+}
+
+function loadManagedUserAccessClients() {
+  if (managedUserAccessClientsRequest) {
+    return managedUserAccessClientsRequest;
+  }
+
+  managedUserAccessClientsRequest =
+    userService.getManagedUserAccessClients().finally(() => {
+      managedUserAccessClientsRequest = null;
+    });
+
+  return managedUserAccessClientsRequest;
 }
 
 export function useManagedUserAccessClients({ enabled = true } = {}) {
@@ -34,7 +49,7 @@ export function useManagedUserAccessClients({ enabled = true } = {}) {
           setIsLoadingAppClients(true);
         }
 
-        const managedClients = await userService.getManagedUserAccessClients();
+        const managedClients = await loadManagedUserAccessClients();
         const clientMap = new Map();
 
         managedClients.forEach((client) => {

--- a/frontend/src/hooks/useUsers.js
+++ b/frontend/src/hooks/useUsers.js
@@ -15,6 +15,7 @@ const ITEMS_PER_PAGE = 10;
 const INVITATION_ACCOUNT_SETUP = "invitation";
 const ADMIN_ACCOUNT_CATEGORY = "system administrator";
 const SYSTEM_ADMINISTRATOR_ACCOUNT_TYPE = "System Administrator";
+const userListRequests = new Map();
 
 function normalizeClientIds(clientIds = []) {
   return Array.from(
@@ -292,27 +293,26 @@ async function getAdminUsers() {
     userService.getAdminUsers({ page, limit: FETCH_LIMIT }),
   );
 
-  const detailedAdminUsers = await Promise.all(
-    adminUsers.map(async (user) => {
-      try {
-        const detailedUser = await userService.getUser(user.id);
-        return mapUserResponse(detailedUser, { isAdmin: true });
-      } catch (error) {
-        console.error(`Failed to load admin user details for ${user.id}:`, error);
-        return mapUserResponse(user, { isAdmin: true });
-      }
-    }),
-  );
-
-  return detailedAdminUsers;
+  return adminUsers.map((user) => mapUserResponse(user, { isAdmin: true }));
 }
 
 async function getUsersByType(userType) {
-  if (userType === ADMIN_USER_TYPE) {
-    return getAdminUsers();
+  const normalizedUserType =
+    userType === ADMIN_USER_TYPE ? ADMIN_USER_TYPE : REGULAR_USER_TYPE;
+  const currentRequest = userListRequests.get(normalizedUserType);
+
+  if (currentRequest) {
+    return currentRequest;
   }
 
-  return getRegularUsers();
+  const nextRequest = (
+    normalizedUserType === ADMIN_USER_TYPE ? getAdminUsers() : getRegularUsers()
+  ).finally(() => {
+    userListRequests.delete(normalizedUserType);
+  });
+
+  userListRequests.set(normalizedUserType, nextRequest);
+  return nextRequest;
 }
 
 async function findRegularUserByEmail(email) {


### PR DESCRIPTION
This PR fixes the User Pool frontend request storm that was causing repeated API calls and possible production rate limiting / 503 Service Temporarily Unavailable errors.

**Summary**
- Uses the existing /admin/users response for regular users, including client access data already returned by the backend.
- Uses /admin/users/admins directly for admin users instead of calling /admin/users/:id for every admin row.
- Stops user-pool app client loading from calling /admin/clients/:id one by one.
- Adds in-flight request guards so repeated React effect runs share the same pending request instead of duplicating backend calls.
- Frontend-only change. No backend code was modified.

**Expected Network Behavior**

- Regular users call /admin/users?page=...&limit=100.
- Admin users call /admin/users/admins?page=...&limit=100.
- User details /admin/users/:id are no longer called for every listed admin.
- App client details /admin/clients/:id are no longer called repeatedly from User Pool.
