### PR TITLE
Fix/page header

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -16,9 +16,8 @@ function MoonIcon() {
   );
 }
 
-export default function Navbar({ sidebarOpen, activeColorMode = "light", onToggleColorMode, showColorModeToggle = false }) {
+export default function Navbar({ activeColorMode = "light", onToggleColorMode, showColorModeToggle = false }) {
   const navigate = useNavigate();
-  const desktopOffsetClassName = sidebarOpen ? "lg:left-80" : "lg:left-32";
   const isDarkMode = activeColorMode === "dark";
   const navbarTheme = isDarkMode
     ? {
@@ -51,7 +50,7 @@ export default function Navbar({ sidebarOpen, activeColorMode = "light", onToggl
     "h-8 w-8 shrink-0 transition-transform duration-300 ease-out group-hover:scale-[1.03]";
 
   return (
-    <nav className={`fixed left-4 right-4 top-4 z-20 overflow-hidden rounded-[1.85rem] border backdrop-blur-2xl transition-all duration-300 sm:top-5 lg:right-6 ${desktopOffsetClassName} ${navbarTheme.shell}`}>
+    <nav className={`sticky top-4 z-20 mx-4 mt-4 overflow-hidden rounded-[1.85rem] border backdrop-blur-2xl transition-all duration-300 sm:top-5 sm:mx-6 sm:mt-5 ${navbarTheme.shell}`}>
       <div className={`pointer-events-none absolute inset-0 ${navbarTheme.shellOverlay}`} />
 
       <div className="relative flex min-h-[4.75rem] items-center justify-between gap-4 px-4 py-3 sm:min-h-[5.25rem] sm:px-6">

--- a/frontend/src/components/PageHeader.jsx
+++ b/frontend/src/components/PageHeader.jsx
@@ -1,87 +1,32 @@
-import { motion } from "framer-motion";
-
-export default function PageHeader({ title, description, icon, variant = "default", colorMode = "light" }) {
+export default function PageHeader({ title, description, icon, colorMode = "light" }) {
   const isDarkMode = colorMode === "dark";
-
-  if (variant === "hero") {
-    return (
-      <div className="mx-auto w-full max-w-[96rem] min-[1800px]:max-w-[112rem] min-[2200px]:max-w-[128rem]">
-        <div className="relative overflow-hidden rounded-[2rem] border border-white/10 shadow-[0_32px_90px_-48px_rgba(43,3,7,0.95)] transition-[border-color,box-shadow] duration-500 ease-out">
-          <div className="absolute inset-0 bg-cover bg-center" style={{ backgroundImage: "url(/assets/images/pup_bg.png)" }}/>
-          <div
-            className={`absolute inset-0 bg-[linear-gradient(135deg,rgba(43,3,7,0.94),rgba(123,13,21,0.84),rgba(24,2,4,0.96))] transition-opacity duration-500 ease-out ${
-              isDarkMode ? "opacity-0" : "opacity-100"
-            }`}
-          />
-          <div
-            className={`absolute inset-0 bg-[linear-gradient(135deg,rgba(15,23,42,0.96),rgba(123,13,21,0.76),rgba(31,18,27,0.96))] transition-opacity duration-500 ease-out ${
-              isDarkMode ? "opacity-100" : "opacity-0"
-            }`}
-          />
-          <div
-            className={`absolute left-[-4rem] top-[-4rem] h-40 w-40 rounded-full bg-[#f8d24e]/20 blur-3xl transition-opacity duration-500 ease-out ${
-              isDarkMode ? "opacity-0" : "opacity-100"
-            }`}
-          />
-          <div
-            className={`absolute left-[-4rem] top-[-4rem] h-40 w-40 rounded-full bg-[#f8d24e]/14 blur-3xl transition-opacity duration-500 ease-out ${
-              isDarkMode ? "opacity-100" : "opacity-0"
-            }`}
-          />
-          <div
-            className={`absolute bottom-[-5rem] right-[-1rem] h-52 w-52 rounded-full bg-white/10 blur-3xl transition-opacity duration-500 ease-out ${
-              isDarkMode ? "opacity-0" : "opacity-100"
-            }`}
-          />
-          <div
-            className={`absolute bottom-[-5rem] right-[-1rem] h-52 w-52 rounded-full bg-[#7b0d15]/20 blur-3xl transition-opacity duration-500 ease-out ${
-              isDarkMode ? "opacity-100" : "opacity-0"
-            }`}
-          />
-
-          <div className="relative px-6 py-6 sm:px-8 sm:py-7">
-            <div className="flex items-center gap-4 sm:gap-5">
-              <motion.div
-                whileHover={{ scale: 1.08, rotate: 10 }}
-                transition={{ duration: 0.35, ease: "easeOut" }}
-                className="shrink-0 text-white"
-              >
-                {icon}
-              </motion.div>
-
-              <div className="min-w-0 space-y-2">
-                <h1 className="text-3xl font-semibold tracking-[0.01em] text-white sm:text-[2.6rem]">
-                  {title}
-                </h1>
-                <p className={`max-w-2xl text-sm leading-6 transition-colors duration-500 ease-out sm:text-base ${isDarkMode ? "text-white/78" : "text-white/75"}`}>
-                  {description}
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
+  const titleClassName = isDarkMode ? "text-white" : "text-[#111827]";
+  const descriptionClassName = isDarkMode
+    ? "text-[#d8c7cb]"
+    : "text-[#64748b]";
+  const iconClassName = "text-white";
+  const titleClasses = [
+    "text-3xl font-black uppercase tracking-[0.02em] sm:text-4xl",
+    titleClassName,
+  ].join(" ");
+  const descriptionClasses = [
+    "mt-1 text-xs font-bold uppercase tracking-[0.16em] sm:text-sm",
+    descriptionClassName,
+  ].join(" ");
+  const iconClasses = ["shrink-0", iconClassName].join(" ");
 
   return (
-    <div className="mx-auto w-full max-w-[80vw] md:max-w-xl lg:max-w-7xl">
-      <div className="flex items-center gap-4">
-        <motion.div
-          whileHover={{ rotate: 2, scale: 1.06, x: 2 }}
-          transition={{ duration: 0.12, ease: "easeOut" }}
-          className="flex h-14 w-14 cursor-pointer items-center justify-center rounded-2xl bg-gray-200 shadow-[0_8px_18px_rgba(0,0,0,0.12)] transition-all hover:shadow-[0_14px_28px_rgba(0,0,0,0.20)]"
-        >
+    <header className="flex w-full items-center gap-3 text-left sm:gap-4">
+      {icon ? (
+        <div className={iconClasses} aria-hidden="true">
           {icon}
-        </motion.div>
-
-        <div>
-          <h1 className="text-2xl font-bold text-[#991b1b] sm:text-4xl">
-            {title}
-          </h1>
-          <p className="text-sm text-gray-600">{description}</p>
         </div>
+      ) : null}
+
+      <div className="min-w-0">
+        <h1 className={titleClasses}>{title}</h1>
+        <p className={descriptionClasses}>{description}</p>
       </div>
-    </div>
+    </header>
   );
 }

--- a/frontend/src/hooks/useAppClients.js
+++ b/frontend/src/hooks/useAppClients.js
@@ -15,12 +15,24 @@ const normalizeRoleNames = (roles = []) =>
     ),
   );
 
-const getClientId = (client = {}) => client.id ?? client.client_id ?? client.clientId ?? "";
+const getClientId = (client = {}) =>
+  client.id ?? client.client_id ?? client.clientId ?? "";
 
-const sortClientsByName = (clients = []) =>
-  [...clients].sort((firstClient, secondClient) =>
-    (firstClient?.name ?? "").localeCompare(secondClient?.name ?? ""),
-  );
+const toPositiveInteger = (value, fallbackValue) => {
+  const parsedValue = Number.parseInt(value, 10);
+
+  return Number.isInteger(parsedValue) && parsedValue > 0
+    ? parsedValue
+    : fallbackValue;
+};
+
+const toNonNegativeInteger = (value, fallbackValue) => {
+  const parsedValue = Number.parseInt(value, 10);
+
+  return Number.isInteger(parsedValue) && parsedValue >= 0
+    ? parsedValue
+    : fallbackValue;
+};
 
 const mapClientSummary = (client = {}) => {
   const clientId = getClientId(client);
@@ -56,90 +68,13 @@ const normalizeClientDetailPayload = (payload = {}) => {
   return mapClientSummary(client);
 };
 
-const matchesClientSearch = (client = {}, searchValue = "") => {
-  const normalizedSearch =
-    typeof searchValue === "string" ? searchValue.trim().toLowerCase() : "";
-
-  if (!normalizedSearch) {
-    return true;
-  }
-
-  const clientName =
-    typeof client?.name === "string" ? client.name.toLowerCase() : "";
-  const clientId =
-    typeof client?.clientId === "string" ? client.clientId.toLowerCase() : "";
-
-  return (
-    clientName.includes(normalizedSearch) ||
-    clientId.includes(normalizedSearch)
-  );
-};
-
-const getMatchingClients = async (keyword) => {
-  const matchedClients = [];
-  let nextPage = 1;
-
-  while (true) {
-    const { items } = await clientService.getClients({
-      limit: ITEMS_PER_PAGE,
-      page: nextPage,
-      keyword,
-    });
-
-    if (!Array.isArray(items) || items.length === 0) {
-      break;
-    }
-
-    matchedClients.push(...items);
-
-    if (items.length < ITEMS_PER_PAGE) {
-      break;
-    }
-
-    nextPage += 1;
-  }
-
-  return matchedClients;
-};
-
-const getManagedClients = async (managedClients = []) => {
-  const uniqueManagedClients = Array.from(
-    new Map(
-      (Array.isArray(managedClients) ? managedClients : [])
-        .map((client) => [getClientId(client), client])
-        .filter(([clientId]) => Boolean(clientId)),
-    ).values(),
-  );
-
-  const detailedClients = await Promise.all(
-    uniqueManagedClients.map(async (client) => {
-      const clientId = getClientId(client);
-
-      try {
-        const payload = await clientService.getClientById(clientId);
-        return normalizeClientDetailPayload(payload);
-      } catch (error) {
-        console.error(`Failed to fetch managed app client ${clientId}:`, error);
-        return mapClientSummary(client);
-      }
-    }),
-  );
-
-  return sortClientsByName(
-    detailedClients.filter((client) => Boolean(client?.id)),
-  );
-};
-
-export function useAppClients({
-  managedClients = null,
-  isManagedClientsLoading = false,
-} = {}) {
+export function useAppClients({ enabled = true } = {}) {
   const [clients, setClients] = useState([]);
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
   const [totalClientCount, setTotalClientCount] = useState(0);
   const [successMessage, setSuccessMessage] = useState("");
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(enabled);
   const [secretModal, setSecretModal] = useState({
     open: false,
     clientId: "",
@@ -150,10 +85,20 @@ export function useAppClients({
     hasError: false,
   });
 
-  const isManagedMode = Array.isArray(managedClients);
   const searchKeyword = search.trim();
 
-  const fetchPageClients = useCallback(async ({ showLoading = true } = {}) => {
+  const resetClients = useCallback(() => {
+    setClients([]);
+    setTotalClientCount(0);
+    setLoading(false);
+  }, []);
+
+  const fetchClients = useCallback(async ({ showLoading = true } = {}) => {
+    if (!enabled) {
+      resetClients();
+      return;
+    }
+
     try {
       if (showLoading) {
         setLoading(true);
@@ -162,14 +107,19 @@ export function useAppClients({
       const { items, total, lastPage } = await clientService.getClients({
         limit: ITEMS_PER_PAGE,
         page,
+        keyword: searchKeyword,
       });
-      const nextClients = items.map(mapClientSummary);
-      const nextTotalResults =
-        Number.isInteger(total) && total >= 0 ? total : nextClients.length;
-      const nextTotalPages =
-        Number.isInteger(lastPage) && lastPage > 0
-          ? lastPage
-          : Math.max(1, Math.ceil(nextTotalResults / ITEMS_PER_PAGE));
+      const nextClients = Array.isArray(items)
+        ? items.map(mapClientSummary)
+        : [];
+      const nextTotalResults = toNonNegativeInteger(
+        total,
+        nextClients.length,
+      );
+      const nextTotalPages = toPositiveInteger(
+        lastPage,
+        Math.max(1, Math.ceil(nextTotalResults / ITEMS_PER_PAGE)),
+      );
 
       if (page > nextTotalPages) {
         setPage(nextTotalPages);
@@ -187,94 +137,20 @@ export function useAppClients({
         setLoading(false);
       }
     }
-  }, [page]);
-
-  const fetchMatchingClients = useCallback(async ({ showLoading = true } = {}) => {
-    try {
-      if (showLoading) {
-        setLoading(true);
-      }
-
-      const matchedClients = await getMatchingClients(searchKeyword);
-      setClients(matchedClients.map(mapClientSummary));
-      setTotalClientCount(matchedClients.length);
-    } catch (error) {
-      console.error("Fetch clients error:", error);
-      setClients([]);
-      setTotalClientCount(0);
-    } finally {
-      if (showLoading) {
-        setLoading(false);
-      }
-    }
-  }, [searchKeyword]);
-
-  const fetchManagedClients = useCallback(async ({ showLoading = true } = {}) => {
-    try {
-      if (showLoading) {
-        setLoading(true);
-      }
-
-      const nextClients = await getManagedClients(managedClients);
-      setClients(nextClients);
-      setTotalClientCount(nextClients.length);
-    } catch (error) {
-      console.error("Fetch managed clients error:", error);
-      setClients([]);
-      setTotalClientCount(0);
-    } finally {
-      if (showLoading) {
-        setLoading(false);
-      }
-    }
-  }, [managedClients]);
+  }, [enabled, page, resetClients, searchKeyword]);
 
   useEffect(() => {
-    if (isManagedMode) {
-      if (isManagedClientsLoading) {
-        setLoading(true);
-        return;
-      }
-
-      fetchManagedClients();
-      return;
-    }
-
-    if (searchKeyword) {
-      return;
-    }
-
-    fetchPageClients();
-  }, [
-    fetchManagedClients,
-    fetchPageClients,
-    isManagedClientsLoading,
-    isManagedMode,
-    searchKeyword,
-  ]);
-
-  useEffect(() => {
-    if (isManagedMode || !searchKeyword) {
-      return;
-    }
-
-    fetchMatchingClients();
-  }, [fetchMatchingClients, isManagedMode, searchKeyword]);
+    fetchClients();
+  }, [fetchClients]);
 
   const setSearchKeyword = useCallback((value) => {
     const nextValue = typeof value === "string" ? value : "";
+
     setPage(1);
     setSearch(nextValue);
   }, []);
 
-  const visibleClients = isManagedMode
-    ? clients.filter((client) => matchesClientSearch(client, searchKeyword))
-    : clients;
-  const shouldPaginateVisibleClients = isManagedMode || Boolean(searchKeyword);
-  const totalResults = isManagedMode
-    ? visibleClients.length
-    : totalClientCount;
-  const totalPages = Math.max(1, Math.ceil(totalResults / ITEMS_PER_PAGE));
+  const totalPages = Math.max(1, Math.ceil(totalClientCount / ITEMS_PER_PAGE));
   const currentPage = Math.min(page, totalPages);
 
   useEffect(() => {
@@ -283,29 +159,13 @@ export function useAppClients({
     }
   }, [currentPage, page]);
 
-  const paginatedClients = shouldPaginateVisibleClients
-    ? visibleClients.slice(
-        (currentPage - 1) * ITEMS_PER_PAGE,
-        currentPage * ITEMS_PER_PAGE,
-      )
-    : visibleClients;
-
   const refreshClients = async ({ showLoading = true } = {}) => {
-    if (isManagedMode) {
-      await fetchManagedClients({ showLoading });
-      return;
-    }
-
-    if (searchKeyword) {
-      await fetchMatchingClients({ showLoading });
-      return;
-    }
-
-    await fetchPageClients({ showLoading });
+    await fetchClients({ showLoading });
   };
 
   const createClient = async (payload) => {
     const response = await clientService.createClient(payload);
+
     setSuccessMessage("App client successfully created!");
     await refreshClients({ showLoading: false });
     return response;
@@ -330,6 +190,7 @@ export function useAppClients({
 
   const getClientDetails = useCallback(async (id) => {
     const payload = await clientService.getClientById(id);
+
     return normalizeClientDetailPayload(payload);
   }, []);
 
@@ -391,9 +252,9 @@ export function useAppClients({
     setSearch: setSearchKeyword,
     page: currentPage,
     setPage,
-    paginatedClients,
+    paginatedClients: clients,
     totalPages,
-    totalResults,
+    totalResults: totalClientCount,
     loading,
     successMessage,
     setSuccessMessage,

--- a/frontend/src/layouts/IdpLayout.jsx
+++ b/frontend/src/layouts/IdpLayout.jsx
@@ -102,7 +102,7 @@ export default function IdpLayout() {
   });
 
   return (
-    <div className={`relative min-h-screen overflow-hidden font-[Poppins] transition-[background-color,color] duration-500 ease-out ${
+    <div className={`relative min-h-screen overflow-x-hidden font-[Poppins] transition-[background-color,color] duration-500 ease-out ${
         isDarkThemeRoute
           ? "bg-[#182434] text-slate-100"
           : "bg-[#fff8f3] text-slate-800"
@@ -176,15 +176,12 @@ export default function IdpLayout() {
 
         <div className="flex min-w-0 flex-1 flex-col">
           <Navbar
-            sidebarOpen={sidebarOpen}
-            currentUser={currentUser}
-            isLoadingCurrentUser={isLoadingCurrentUser}
             activeColorMode={colorMode}
             onToggleColorMode={handleToggleColorMode}
             showColorModeToggle={showColorModeToggle}
           />
 
-          <main className="flex-1 px-4 pb-32 pt-28 sm:px-6 sm:pb-32 sm:pt-32 lg:px-6 lg:pb-8 lg:pt-36">
+          <main className="flex-1 px-4 pb-32 pt-6 sm:px-6 sm:pb-32 sm:pt-7 lg:px-6 lg:pb-8 lg:pt-8">
             <PageTransition pageKey={location.pathname}>
               {outlet}
             </PageTransition>

--- a/frontend/src/pages/AppClient.jsx
+++ b/frontend/src/pages/AppClient.jsx
@@ -2,7 +2,6 @@ import { useOutletContext } from "react-router-dom";
 import { useState } from "react";
 import { usePermissionAccess } from "../context/PermissionContext";
 import { useAppClients } from "../hooks/useAppClients";
-import { useManagedUserAccessClients } from "../hooks/useManagedUserAccessClients";
 import ConnectedAppClientCard from "../components/app-client/ConnectedAppClientCard";
 import AppClientModal from "../components/app-client/AppClientModal";
 import AppClientCreateModal from "../components/app-client/AppClientCreateModal";
@@ -24,20 +23,10 @@ export default function AppClient() {
     const canEditClient = hasPermission(PERMISSIONS.EDIT_APPCLIENT);
     const canDeleteClient = hasPermission(PERMISSIONS.DELETE_APPCLIENT);
     const canViewAllClients = hasPermission(PERMISSIONS.VIEW_ALL_APPCLIENTS);
-    const shouldUseManagedClients =
-        !canViewAllClients && (canEditClient || canDeleteClient);
-    const {
-        appClients: managedClients,
-        isLoadingAppClients: isLoadingManagedClients,
-        refreshAppClients: refreshManagedClients,
-    } = useManagedUserAccessClients({ enabled: shouldUseManagedClients });
-    const scopedClients = canViewAllClients
-        ? null
-        : shouldUseManagedClients
-            ? managedClients
-            : [];
-    const isScopedClientListLoading =
-        shouldUseManagedClients && isLoadingManagedClients;
+    const canViewConnectedClients = hasPermission(
+        PERMISSIONS.VIEW_CONNECTED_APPCLIENTS,
+    );
+    const canViewClientList = canViewAllClients || canViewConnectedClients;
     const {
         search, setSearch, page, setPage,
         paginatedClients, totalPages, totalResults,
@@ -46,10 +35,7 @@ export default function AppClient() {
         createClient, updateClient, deleteClient,
         getClientDetails,
         rotateClientSecret, secretModal, setSecretModal,
-    } = useAppClients({
-        managedClients: scopedClients,
-        isManagedClientsLoading: isScopedClientListLoading,
-    });
+    } = useAppClients({ enabled: canViewClientList });
     const [createOpen, setCreateOpen] = useState(false);
     const [editViewOpen, setEditViewOpen] = useState(false);
     const [mode, setMode] = useState("create");
@@ -58,15 +44,11 @@ export default function AppClient() {
     const [deleteTarget, setDeleteTarget] = useState(null);
     const [showSecretConfirm, setShowSecretConfirm] = useState(false);
     const [secretTarget, setSecretTarget] = useState(null);
-    const showLoading = useDelayedLoading(loading || isScopedClientListLoading);
+    const showLoading = useDelayedLoading(loading);
     const canRotateClientSecret = canEditClient;
 
     const handleCreateClient = async (payload) => {
         const res = await createClient(payload);
-
-        if (shouldUseManagedClients) {
-            refreshManagedClients({ showLoading: false });
-        }
 
         setSecretModal({
             open: true,
@@ -119,10 +101,6 @@ export default function AppClient() {
 
         try {
             await deleteClient(deleteTarget);
-
-            if (shouldUseManagedClients) {
-                refreshManagedClients({ showLoading: false });
-            }
         } finally {
             setShowDeleteAlert(false);
             setDeleteTarget(null);

--- a/frontend/src/pages/AppClient.jsx
+++ b/frontend/src/pages/AppClient.jsx
@@ -169,9 +169,8 @@ export default function AppClient() {
                     title="App Client"
                     description="Manage application clients and settings"
                     icon={
-                        <AppClientIcon className="h-20 w-20 sm:h-24 sm:w-24" />
+                        <AppClientIcon className="h-14 w-14 sm:h-16 sm:w-16" />
                     }
-                    variant="hero"
                     colorMode={colorMode}
                 />
                 <div className="relative">

--- a/frontend/src/pages/AuditLogs.jsx
+++ b/frontend/src/pages/AuditLogs.jsx
@@ -274,15 +274,14 @@ export default function AuditLogs() {
         <PageHeader
           title="Audit Logs"
           description="Track transaction and security activity"
-          colorMode={colorMode}
           icon={
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-20 w-20 sm:h-24 sm:w-24">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-14 w-14 sm:h-16 sm:w-16">
               <path d="M11.625 16.5a1.875 1.875 0 1 0 0-3.75 1.875 1.875 0 0 0 0 3.75Z" />
               <path fillRule="evenodd" d="M5.625 1.5H9a3.75 3.75 0 0 1 3.75 3.75v1.875c0 1.036.84 1.875 1.875 1.875H16.5a3.75 3.75 0 0 1 3.75 3.75v7.875c0 1.035-.84 1.875-1.875 1.875H5.625a1.875 1.875 0 0 1-1.875-1.875V3.375c0-1.036.84-1.875 1.875-1.875Zm6 16.5c.66 0 1.277-.19 1.797-.518l1.048 1.048a.75.75 0 0 0 1.06-1.06l-1.047-1.048A3.375 3.375 0 1 0 11.625 18Z" clipRule="evenodd" />
               <path d="M14.25 5.25a5.23 5.23 0 0 0-1.279-3.434 9.768 9.768 0 0 1 6.963 6.963A5.23 5.23 0 0 0 16.5 7.5h-1.875a.375.375 0 0 1-.375-.375V5.25Z" />
             </svg>
           }
-          variant="hero"
+          colorMode={colorMode}
         />
 
         <div className="relative">

--- a/frontend/src/pages/Registration.jsx
+++ b/frontend/src/pages/Registration.jsx
@@ -351,14 +351,13 @@ export default function Registration() {
         <PageHeader
           title="Registration"
           description="Configure pre-approved app clients for each account type."
-          colorMode={colorMode}
           icon={
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-20 w-20 sm:h-24 sm:w-24">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-14 w-14 sm:h-16 sm:w-16">
               <path fillRule="evenodd" d="M9 1.5H5.625c-1.036 0-1.875.84-1.875 1.875v17.25c0 1.035.84 1.875 1.875 1.875h12.75c1.035 0 1.875-.84 1.875-1.875V12.75A3.75 3.75 0 0 0 16.5 9h-1.875a1.875 1.875 0 0 1-1.875-1.875V5.25A3.75 3.75 0 0 0 9 1.5Zm6.61 10.936a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 14.47a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z" clipRule="evenodd"/>
               <path d="M12.971 1.816A5.23 5.23 0 0 1 14.25 5.25v1.875c0 .207.168.375.375.375H16.5a5.23 5.23 0 0 1 3.434 1.279 9.768 9.768 0 0 0-6.963-6.963Z" />
             </svg>
           }
-          variant="hero"
+          colorMode={colorMode}
         />
 
         <div className="relative">

--- a/frontend/src/pages/Roles.jsx
+++ b/frontend/src/pages/Roles.jsx
@@ -107,14 +107,13 @@ export default function Roles() {
       <div className="mx-auto flex w-full min-w-0 max-w-[96rem] flex-col gap-6 px-1 min-[1800px]:max-w-[112rem] min-[2200px]:max-w-[128rem] sm:px-0">
         <PageHeader
           title="Roles"
-          description="Manage system roles and permissions"
-          colorMode={colorMode}
+          description="Manage roles and permissions"
           icon={
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-20 w-20 sm:h-24 sm:w-24">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-14 w-14 sm:h-16 sm:w-16">
               <path fillRule="evenodd" d="M9.661 2.237a.531.531 0 0 1 .678 0 11.947 11.947 0 0 0 7.078 2.749.5.5 0 0 1 .479.425c.069.52.104 1.05.104 1.59 0 5.162-3.26 9.563-7.834 11.256a.48.48 0 0 1-.332 0C5.26 16.564 2 12.163 2 7c0-.538.035-1.069.104-1.589a.5.5 0 0 1 .48-.425 11.947 11.947 0 0 0 7.077-2.75Zm4.196 5.954a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clipRule="evenodd" />
             </svg>
           }
-          variant="hero"
+          colorMode={colorMode}
         />
 
         <div className="relative">

--- a/frontend/src/pages/UserPool.jsx
+++ b/frontend/src/pages/UserPool.jsx
@@ -160,14 +160,13 @@ export default function UserPool() {
       <div className="mx-auto flex w-full min-w-0 max-w-[96rem] flex-col gap-6 px-1 min-[1800px]:max-w-[112rem] min-[2200px]:max-w-[128rem] sm:px-0">
         <PageHeader
           title="Users"
-          description="Manage and view user accounts in the user pool"
-          colorMode={colorMode}
+          description="Manage user accounts"
           icon={
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-20 w-20 sm:h-24 sm:w-24">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-14 w-14 sm:h-16 sm:w-16">
               <path fillRule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-5.5-2.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0ZM10 12a5.99 5.99 0 0 0-4.793 2.39A6.483 6.483 0 0 0 10 16.5a6.483 6.483 0 0 0 4.793-2.11A5.99 5.99 0 0 0 10 12Z" clipRule="evenodd"/>
             </svg>
           }
-          variant="hero"
+          colorMode={colorMode}
         />
 
         <div className="relative">

--- a/frontend/src/utils/permissionAccess.js
+++ b/frontend/src/utils/permissionAccess.js
@@ -12,6 +12,7 @@ export const PERMISSIONS = Object.freeze({
   EDIT_APPCLIENT: "Edit appclient",
   DELETE_APPCLIENT: "Delete appclient",
   VIEW_ALL_APPCLIENTS: "View all appclients",
+  VIEW_CONNECTED_APPCLIENTS: "View connected appclients",
   VIEW_ROLES: "View roles",
   ASSIGN_ROLES: "Assign Roles",
   EDIT_ROLES: "Edit Roles",
@@ -57,6 +58,7 @@ export const REGISTRATION_EDIT_PERMISSIONS = Object.freeze([
 
 export const APP_CLIENT_PAGE_PERMISSIONS = Object.freeze([
   PERMISSIONS.VIEW_ALL_APPCLIENTS,
+  PERMISSIONS.VIEW_CONNECTED_APPCLIENTS,
   PERMISSIONS.ADD_APPCLIENT,
   PERMISSIONS.EDIT_APPCLIENT,
   PERMISSIONS.DELETE_APPCLIENT,


### PR DESCRIPTION
This PR updates frontend-only behavior for the App Client page and shared layout/header UI.

**Changes**
- Updated the App Client page to use the scoped /admin/clients list endpoint instead of loading /admin/users/access and then fetching each client one by one.
- Added frontend support for the View connected appclients permission so scoped admins can access the App Client page.
- Removed repeated App Client list detail requests that caused client not found network errors.
- Kept detailed client fetching only when opening View/Edit.
- Simplified page headers by removing the old large container while keeping title, description, and larger white icons.
- Made the navbar sticky in the page layout so it stays above the page header without overlapping it.