### PR TITLE
update client repository join table from client_allowed_users to admi…

### DIFF
--- a/backend/internal/repository/client_repository.go
+++ b/backend/internal/repository/client_repository.go
@@ -116,7 +116,7 @@ func (r *clientRepository) ListBoundClients(ctx context.Context,
 			c.description, c.image_location,
 			c.base_url, c.redirect_uri, c.logout_uri, c.created_at
 		FROM clients c
-		JOIN client_allowed_users a ON c.id = a.client_id
+		JOIN admin_allowed_clients a ON c.id = a.client_id
 		WHERE a.user_id = ?
 			AND c.deleted_at IS NULL
 			AND c.client_name LIKE ?
@@ -273,7 +273,7 @@ func (r *clientRepository) CountBoundClients(ctx context.Context,
 	query := `
 		SELECT COUNT(*)
 		FROM clients c
-		JOIN client_allowed_users a ON c.id = a.client_id
+		JOIN admin_allowed_clients a ON c.id = a.client_id
 		WHERE a.user_id = ? 
 			AND c.deleted_at IS NULL 
 			AND c.client_name LIKE ?


### PR DESCRIPTION
This pull request updates the logic for listing and counting bound clients to use the `admin_allowed_clients` table instead of the `client_allowed_users` table. This change ensures that client associations are now based on admin permissions rather than user-specific permissions.

**Database query updates:**

* Updated the `ListBoundClients` method in `client_repository.go` to join with the `admin_allowed_clients` table instead of `client_allowed_users` for retrieving client information.
* Updated the `CountBoundClients` method in `client_repository.go` to join with the `admin_allowed_clients` table instead of `client_allowed_users`.