### PR TITLE
Fix/service call

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+.vite
+.cache
+coverage
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.env
+.env.*

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 
 # Install dependencies in a clean, deterministic way
-RUN npm install
+RUN npm ci && npm cache clean --force
 
 # Copy the rest of the application source code
 COPY . .

--- a/frontend/src/components/app-client/AppClientCreateModal.jsx
+++ b/frontend/src/components/app-client/AppClientCreateModal.jsx
@@ -517,7 +517,8 @@ export default function AppClientCreateModal({ open, onClose, onSubmit, colorMod
     } catch (submitError) {
       console.error("Create app client error:", submitError);
       setError(
-        "Unable to create app client. Please review the details and try again.",
+        submitError?.message ||
+          "Unable to create app client. Please review the details and try again.",
       );
     }
   };

--- a/frontend/src/components/app-client/AppClientModal.jsx
+++ b/frontend/src/components/app-client/AppClientModal.jsx
@@ -472,7 +472,10 @@ export default function AppClientModal({ open, mode, client, getClientDetails, o
       onClose();
     } catch (submitError) {
       console.error("Submit app client error:", submitError);
-      setError("Unable to save app client. Please review the details and try again.");
+      setError(
+        submitError?.message ||
+          "Unable to save app client. Please review the details and try again.",
+      );
     }
   };
 

--- a/frontend/src/services/clientService.js
+++ b/frontend/src/services/clientService.js
@@ -1,4 +1,7 @@
-import axiosInstance from "../services/axiosInstance";
+import axiosInstance from "./axiosInstance";
+import { clearCachedRequests, getCachedRequest } from "../utils/requestCache";
+
+const CLIENT_CACHE_PREFIX = "client:";
 
 const normalizeStringValue = (value) =>
   typeof value === "string" ? value : "";
@@ -177,37 +180,44 @@ export const clientService = {
     const normalizedPage =
       Number.isInteger(page) && page > 0 ? page : 1;
 
-    const response = await axiosInstance.get("/admin/clients", {
-      params: {
-        limit,
-        page: normalizedPage,
-        ...(normalizedKeyword ? { keyword: normalizedKeyword } : {}),
+    return getCachedRequest(
+      `${CLIENT_CACHE_PREFIX}list:${limit}:${normalizedPage}:${normalizedKeyword}`,
+      async () => {
+        const response = await axiosInstance.get("/admin/clients", {
+          params: {
+            limit,
+            page: normalizedPage,
+            ...(normalizedKeyword ? { keyword: normalizedKeyword } : {}),
+          },
+        });
+
+        const payload = normalizeResponsePayload(response.data);
+        const items = getClientItems(payload);
+        const total =
+          payload.total_count ??
+          payload.total ??
+          payload.count ??
+          payload.totalResults ??
+          items.length;
+        const lastPage =
+          payload.last_page ??
+          payload.lastPage ??
+          Math.max(1, Math.ceil(total / limit));
+
+        return {
+          items,
+          total: Number.isInteger(total) ? total : items.length,
+          lastPage: Number.isInteger(lastPage) && lastPage > 0 ? lastPage : 1,
+        };
       },
-    });
-
-    const payload = normalizeResponsePayload(response.data);
-    const items = getClientItems(payload);
-    const total =
-      payload.total_count ??
-      payload.total ??
-      payload.count ??
-      payload.totalResults ??
-      items.length;
-    const lastPage =
-      payload.last_page ??
-      payload.lastPage ??
-      Math.max(1, Math.ceil(total / limit));
-
-    return {
-      items,
-      total: Number.isInteger(total) ? total : items.length,
-      lastPage: Number.isInteger(lastPage) && lastPage > 0 ? lastPage : 1,
-    };
+    );
   },
 
   async getClientById(id) {
-    const response = await axiosInstance.get(`/admin/clients/${id}`);
-    return response.data;
+    return getCachedRequest(`${CLIENT_CACHE_PREFIX}detail:${id}`, async () => {
+      const response = await axiosInstance.get(`/admin/clients/${id}`);
+      return response.data;
+    });
   },
 
   async createClient(data) {
@@ -216,6 +226,7 @@ export const clientService = {
       headers: { "Content-Type": "multipart/form-data" },
     });
 
+    clearCachedRequests(CLIENT_CACHE_PREFIX);
     return response.data;
   },
 
@@ -225,16 +236,19 @@ export const clientService = {
       headers: { "Content-Type": "multipart/form-data" },
     });
 
+    clearCachedRequests(CLIENT_CACHE_PREFIX);
     return response.data;
   },
 
   async deleteClient(id) {
     const response = await axiosInstance.delete(`/admin/clients/${id}`);
+    clearCachedRequests(CLIENT_CACHE_PREFIX);
     return response.data;
   },
 
   async rotateClientSecret(id) {
     const response = await axiosInstance.patch(`/admin/clients/${id}/secret`);
+    clearCachedRequests(CLIENT_CACHE_PREFIX);
     return normalizeRotateSecretPayload(response?.data, id);
   },
 };

--- a/frontend/src/services/clientService.js
+++ b/frontend/src/services/clientService.js
@@ -2,6 +2,7 @@ import axiosInstance from "./axiosInstance";
 import { clearCachedRequests, getCachedRequest } from "../utils/requestCache";
 
 const CLIENT_CACHE_PREFIX = "client:";
+const MAX_CLIENT_IMAGE_BYTES = 5 * 1024 * 1024;
 
 const normalizeStringValue = (value) =>
   typeof value === "string" ? value : "";
@@ -10,6 +11,19 @@ const normalizeStringList = (values = []) =>
   (Array.isArray(values) ? values : []).filter(
     (value) => typeof value === "string" && value.trim().length > 0,
   );
+
+function validateClientImageFile(imageFile) {
+  if (!imageFile) {
+    return;
+  }
+
+  if (
+    Number.isFinite(imageFile.size) &&
+    imageFile.size > MAX_CLIENT_IMAGE_BYTES
+  ) {
+    throw new Error("System logo must be 5MB max.");
+  }
+}
 
 function parseJsonChunk(chunk) {
   try {
@@ -145,6 +159,7 @@ const buildClientFormData = (data = {}) => {
   });
 
   if (data.imageFile) {
+    validateClientImageFile(data.imageFile);
     formData.append("image", data.imageFile);
   }
 

--- a/frontend/src/services/permissionService.js
+++ b/frontend/src/services/permissionService.js
@@ -1,19 +1,28 @@
 import axiosInstance from "./axiosInstance";
+import { getCachedRequest } from "../utils/requestCache";
+
+const PERMISSION_CACHE_PREFIX = "permission:";
 
 export const permissionService = {
   async getPermissions() {
-    const response = await axiosInstance.get("/admin/permissions/all", {
-      skipForbiddenAlert: true,
+    return getCachedRequest(`${PERMISSION_CACHE_PREFIX}all`, async () => {
+      const response = await axiosInstance.get("/admin/permissions/all", {
+        skipForbiddenAlert: true,
+      });
+
+      return Array.isArray(response.data) ? response.data : [];
     });
-    return Array.isArray(response.data) ? response.data : [];
   },
 
   async getCurrentUserPermissions() {
-    const response = await axiosInstance.get("/admin/permissions", {
-      skipForbiddenAlert: true,
+    return getCachedRequest(`${PERMISSION_CACHE_PREFIX}current`, async () => {
+      const response = await axiosInstance.get("/admin/permissions", {
+        skipForbiddenAlert: true,
+      });
+
+      return Array.isArray(response.data?.permissions)
+        ? response.data.permissions
+        : [];
     });
-    return Array.isArray(response.data?.permissions)
-      ? response.data.permissions
-      : [];
   },
 };

--- a/frontend/src/services/registrationService.js
+++ b/frontend/src/services/registrationService.js
@@ -1,7 +1,9 @@
 import axiosInstance from "./axiosInstance";
 import { buildAccountTypeOption, getAccountTypeBackendId, normalizeAccountType } from "../utils/accountTypes";
+import { clearCachedRequests, getCachedRequest } from "../utils/requestCache";
 
 const REGISTRATION_BASE_PATH = "/admin/registration";
+const REGISTRATION_CACHE_PREFIX = "registration:";
 const CREATE_ACCOUNT_TYPE_PLACEHOLDER_ID = 1;
 
 function normalizeTextValue(value) {
@@ -57,20 +59,22 @@ function normalizeAccountTypeConfig(
 
 export const registrationService = {
   async getRegistrationConfig(requestConfig = {}) {
-    const response = await axiosInstance.get(
-      `${REGISTRATION_BASE_PATH}/config`,
-      requestConfig,
-    );
-    const payload = response.data ?? {};
-    const accountTypes = Array.isArray(payload?.account_types)
-      ? payload.account_types
-      : Array.isArray(payload?.accountTypes)
-        ? payload.accountTypes
-        : [];
+    return getCachedRequest(`${REGISTRATION_CACHE_PREFIX}config`, async () => {
+      const response = await axiosInstance.get(
+        `${REGISTRATION_BASE_PATH}/config`,
+        requestConfig,
+      );
+      const payload = response.data ?? {};
+      const accountTypes = Array.isArray(payload?.account_types)
+        ? payload.account_types
+        : Array.isArray(payload?.accountTypes)
+          ? payload.accountTypes
+          : [];
 
-    return accountTypes
-      .map((config) => normalizeAccountTypeConfig(config))
-      .filter((config) => config.accountTypeValue);
+      return accountTypes
+        .map((config) => normalizeAccountTypeConfig(config))
+        .filter((config) => config.accountTypeValue);
+    });
   },
 
   async getClientsByAccountTypeId(
@@ -78,15 +82,20 @@ export const registrationService = {
     fallbackAccountType = "",
     requestConfig = {},
   ) {
-    const response = await axiosInstance.get(
-      `${REGISTRATION_BASE_PATH}/config/${accountTypeId}`,
-      requestConfig,
-    );
+    return getCachedRequest(
+      `${REGISTRATION_CACHE_PREFIX}config:${accountTypeId}`,
+      async () => {
+        const response = await axiosInstance.get(
+          `${REGISTRATION_BASE_PATH}/config/${accountTypeId}`,
+          requestConfig,
+        );
 
-    return normalizeAccountTypeConfig(
-      response.data,
-      fallbackAccountType,
-      accountTypeId,
+        return normalizeAccountTypeConfig(
+          response.data,
+          fallbackAccountType,
+          accountTypeId,
+        );
+      },
     );
   },
 
@@ -109,6 +118,7 @@ export const registrationService = {
       },
     );
 
+    clearCachedRequests(REGISTRATION_CACHE_PREFIX);
     return response.data;
   },
 
@@ -135,6 +145,7 @@ export const registrationService = {
       },
     );
 
+    clearCachedRequests(REGISTRATION_CACHE_PREFIX);
     return response.data;
   },
 
@@ -147,6 +158,7 @@ export const registrationService = {
       `${REGISTRATION_BASE_PATH}/config/${accountTypeId}`,
     );
 
+    clearCachedRequests(REGISTRATION_CACHE_PREFIX);
     return response.data;
   },
 

--- a/frontend/src/services/roleService.js
+++ b/frontend/src/services/roleService.js
@@ -1,4 +1,7 @@
 import axiosInstance from "./axiosInstance";
+import { clearCachedRequests, getCachedRequest } from "../utils/requestCache";
+
+const ROLE_CACHE_PREFIX = "role:";
 
 const normalizeTextValue = (value) =>
   typeof value === "string" ? value.trim() : "";
@@ -43,39 +46,55 @@ const normalizeClientTagOption = (client = {}) => {
 export const roleService = {
   async getRoles(page = 1, { keyword = "" } = {}) {
     const normalizedKeyword = normalizeTextValue(keyword);
-    const response = await axiosInstance.get("/admin/roles", {
-      params: {
-        page,
-        ...(normalizedKeyword ? { keyword: normalizedKeyword } : {}),
-      },
-    });
 
-    return response.data;
+    return getCachedRequest(
+      `${ROLE_CACHE_PREFIX}list:${page}:${normalizedKeyword}`,
+      async () => {
+        const response = await axiosInstance.get("/admin/roles", {
+          params: {
+            page,
+            ...(normalizedKeyword ? { keyword: normalizedKeyword } : {}),
+          },
+        });
+
+        return response.data;
+      },
+    );
   },
 
   async getAllRolesPage(page = 1, { keyword = "" } = {}) {
     const normalizedKeyword = normalizeTextValue(keyword);
-    const response = await axiosInstance.get("/admin/roles/all", {
-      params: {
-        page,
-        ...(normalizedKeyword ? { keyword: normalizedKeyword } : {}),
-      },
-    });
 
-    return response.data;
+    return getCachedRequest(
+      `${ROLE_CACHE_PREFIX}all:${page}:${normalizedKeyword}`,
+      async () => {
+        const response = await axiosInstance.get("/admin/roles/all", {
+          params: {
+            page,
+            ...(normalizedKeyword ? { keyword: normalizedKeyword } : {}),
+          },
+        });
+
+        return response.data;
+      },
+    );
   },
 
   async getAllRoles() {
-    const response = await axiosInstance.get("/admin/roles", {
-      params: { page: 1, limit: 10 },
-    });
+    return getCachedRequest(`${ROLE_CACHE_PREFIX}summary`, async () => {
+      const response = await axiosInstance.get("/admin/roles", {
+        params: { page: 1, limit: 10 },
+      });
 
-    return response.data.roles;
+      return response.data.roles;
+    });
   },
 
   async getRoleById(id) {
-    const response = await axiosInstance.get(`/admin/roles/${id}`);
-    return response.data;
+    return getCachedRequest(`${ROLE_CACHE_PREFIX}detail:${id}`, async () => {
+      const response = await axiosInstance.get(`/admin/roles/${id}`);
+      return response.data;
+    });
   },
 
   async getClientTags({ limit = 50, keyword = "" } = {}) {
@@ -131,6 +150,7 @@ export const roleService = {
       buildRolePayload(data),
     );
 
+    clearCachedRequests(ROLE_CACHE_PREFIX);
     return response.data;
   },
 
@@ -140,11 +160,13 @@ export const roleService = {
       buildRolePayload(data),
     );
 
+    clearCachedRequests(ROLE_CACHE_PREFIX);
     return response.data;
   },
 
   async deleteRole(id) {
     const response = await axiosInstance.delete(`/admin/roles/${id}`);
+    clearCachedRequests(ROLE_CACHE_PREFIX);
     return response.data;
   },
 };

--- a/frontend/src/services/userService.js
+++ b/frontend/src/services/userService.js
@@ -1,7 +1,10 @@
 import axiosInstance from "./axiosInstance";
+import { clearCachedRequests, getCachedRequest } from "../utils/requestCache";
 
 const DEFAULT_PAGE = 1;
 const DEFAULT_LIMIT = 100;
+const USER_CACHE_PREFIX = "user:";
+const CURRENT_USER_CACHE_KEY = `${USER_CACHE_PREFIX}me`;
 const UUID_PATTERN =
   /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/i;
 
@@ -49,29 +52,47 @@ const extractCreatedUserId = (payload = {}) => {
   return matchedUserId?.[0] ?? "";
 };
 
+const clearUserCache = () => {
+  clearCachedRequests(USER_CACHE_PREFIX);
+};
+
 export const userService = {
   async getMe() {
-    const res = await axiosInstance.get("/me");
-    return res.data;
+    return getCachedRequest(CURRENT_USER_CACHE_KEY, async () => {
+      const res = await axiosInstance.get("/me");
+      return res.data;
+    });
   },
 
   async getUsers({ page = DEFAULT_PAGE, limit = DEFAULT_LIMIT } = {}) {
-    const res = await axiosInstance.get("/admin/users", {
-      params: { page, limit },
-    });
-    return res.data;
+    return getCachedRequest(
+      `${USER_CACHE_PREFIX}list:${page}:${limit}`,
+      async () => {
+        const res = await axiosInstance.get("/admin/users", {
+          params: { page, limit },
+        });
+        return res.data;
+      },
+    );
   },
 
   async getAdminUsers({ page = DEFAULT_PAGE, limit = DEFAULT_LIMIT } = {}) {
-    const res = await axiosInstance.get("/admin/users/admins", {
-      params: { page, limit },
-    });
-    return res.data;
+    return getCachedRequest(
+      `${USER_CACHE_PREFIX}admins:${page}:${limit}`,
+      async () => {
+        const res = await axiosInstance.get("/admin/users/admins", {
+          params: { page, limit },
+        });
+        return res.data;
+      },
+    );
   },
 
   async getUser(id) {
-    const res = await axiosInstance.get(`/admin/users/${id}`);
-    return res.data;
+    return getCachedRequest(`${USER_CACHE_PREFIX}detail:${id}`, async () => {
+      const res = await axiosInstance.get(`/admin/users/${id}`);
+      return res.data;
+    });
   },
 
   async updateUserName(id, data = {}) {
@@ -108,6 +129,7 @@ export const userService = {
       },
     );
 
+    clearUserCache();
     return res.data;
   },
 
@@ -135,6 +157,7 @@ export const userService = {
       headers: { "Content-Type": "application/json" },
     });
 
+    clearUserCache();
     return {
       ...(res.data ?? {}),
       createdUserId: extractCreatedUserId(res.data),
@@ -157,6 +180,7 @@ export const userService = {
       headers: { "Content-Type": "application/json" },
     });
 
+    clearUserCache();
     return res.data;
   },
 
@@ -170,6 +194,7 @@ export const userService = {
       headers: { "Content-Type": "application/json" },
     });
 
+    clearUserCache();
     return res.data;
   },
 
@@ -182,6 +207,7 @@ export const userService = {
       headers: { "Content-Type": "application/json" },
     });
 
+    clearUserCache();
     return res.data;
   },
 
@@ -198,11 +224,13 @@ export const userService = {
       },
     );
 
+    clearUserCache();
     return res.data;
   },
 
   async deleteUser(id) {
     const res = await axiosInstance.delete(`/admin/users/${id}`);
+    clearUserCache();
     return res.data;
   },
 };

--- a/frontend/src/utils/requestCache.js
+++ b/frontend/src/utils/requestCache.js
@@ -1,0 +1,58 @@
+const DEFAULT_CACHE_MS = 500;
+const cachedRequests = new Map();
+
+export function getCachedRequest(
+  key,
+  requestFactory,
+  { cacheMs = DEFAULT_CACHE_MS } = {},
+) {
+  const cachedRequest = cachedRequests.get(key);
+  const now = Date.now();
+
+  if (cachedRequest?.promise) {
+    return cachedRequest.promise;
+  }
+
+  if (
+    cachedRequest &&
+    Object.prototype.hasOwnProperty.call(cachedRequest, "data") &&
+    now - cachedRequest.timestamp < cacheMs
+  ) {
+    return Promise.resolve(cachedRequest.data);
+  }
+
+  const promise = Promise.resolve()
+    .then(requestFactory)
+    .then((data) => {
+      cachedRequests.set(key, {
+        data,
+        timestamp: Date.now(),
+      });
+
+      return data;
+    })
+    .catch((error) => {
+      cachedRequests.delete(key);
+      throw error;
+    });
+
+  cachedRequests.set(key, {
+    promise,
+    timestamp: now,
+  });
+
+  return promise;
+}
+
+export function clearCachedRequests(prefix = "") {
+  if (!prefix) {
+    cachedRequests.clear();
+    return;
+  }
+
+  Array.from(cachedRequests.keys()).forEach((key) => {
+    if (key.startsWith(prefix)) {
+      cachedRequests.delete(key);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Fixed duplicate frontend API calls by reusing short-lived in-flight GET requests.
- Added frontend cache invalidation after related create/update/delete actions.
- Enforced the 5MB app-client logo upload limit in the frontend service layer.
- Reduced frontend Docker image size by adding `.dockerignore` and using `npm ci`.