### PR TITLE
unify credential failure status codes to 401

### DIFF
--- a/backend/internal/api/v1/auth_handler.go
+++ b/backend/internal/api/v1/auth_handler.go
@@ -223,7 +223,7 @@ func (h *AuthHandler) LoginAndAuthorize(c *gin.Context) {
 		status := http.StatusInternalServerError
 		msg := "internal error"
 
-		if strings.Contains(err.Error(), "Verification") ||
+		if strings.Contains(err.Error(), "verification") ||
 			strings.Contains(err.Error(), "UserLookup") {
 			status = http.StatusUnauthorized
 			msg = "invalid credentials"
@@ -602,7 +602,7 @@ func (h *AuthHandler) PostTokenExchange(c *gin.Context) {
 		status := http.StatusInternalServerError
 		errorMsg := "server_error"
 
-		if strings.Contains(err.Error(), "Verification") {
+		if strings.Contains(err.Error(), "verification") {
 			status, errorMsg = http.StatusUnauthorized, "unauthorized"
 		} else if strings.Contains(err.Error(), "Code Exchange") {
 			status, errorMsg = http.StatusBadRequest, "invalid_grant"

--- a/backend/internal/api/v1/user_handler.go
+++ b/backend/internal/api/v1/user_handler.go
@@ -575,8 +575,8 @@ func (h *UserHandler) PatchChangePassword(c *gin.Context) {
 	if err != nil {
 		log.Printf("[PatchChangePassword] %v", err)
 		status := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "Verification") {
-			status = http.StatusBadRequest
+		if strings.Contains(err.Error(), "verification") {
+			status = http.StatusUnauthorized
 		}
 
 		_ = h.LogService.PostAuditLogWithActorString(ctx, actorName,


### PR DESCRIPTION
- Update LoginAndAuthorize and PostTokenExchange to use lowercase 'verification' string matching to catch password failures.
- Update PatchChangePassword to use lowercase 'verification' and return 401 Unauthorized for credential mismatches.
- Ensure 'invalid credentials' response for both email and password failures during login.