### PR TITLE
Transition security log endpoints to granular View security logs permission

### DIFF
--- a/backend/internal/api/v1/log_handler.go
+++ b/backend/internal/api/v1/log_handler.go
@@ -183,7 +183,7 @@ func (h *LogHandler) GetLog(c *gin.Context) {
 // @Failure 500 {object} dto.ErrorResponse
 // @Router /logs/security [get]
 func (h *LogHandler) GetSecurityLogList(c *gin.Context) {
-	if !middleware.HasPermission(c, "View audit logs") {
+	if !middleware.HasPermission(c, "View security logs") {
 		c.JSON(http.StatusUnauthorized, dto.ErrorResponse{Error: "Unauthorized"})
 		return
 	}
@@ -246,7 +246,7 @@ func (h *LogHandler) GetSecurityLogList(c *gin.Context) {
 // @Failure 500 {object} dto.ErrorResponse
 // @Router /logs/security/{id} [get]
 func (h *LogHandler) GetSecurityLog(c *gin.Context) {
-	if !middleware.HasPermission(c, "View audit logs") {
+	if !middleware.HasPermission(c, "View security logs") {
 		c.JSON(http.StatusUnauthorized, dto.ErrorResponse{Error: "Unauthorized"})
 		return
 	}

--- a/backend/tests/handler/log_handler_security_test.go
+++ b/backend/tests/handler/log_handler_security_test.go
@@ -1,0 +1,96 @@
+package handler_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Iskolutions-Capstone-Dev-Team/Identity-Provider/internal/api/v1"
+	"github.com/Iskolutions-Capstone-Dev-Team/Identity-Provider/internal/dto"
+	"github.com/Iskolutions-Capstone-Dev-Team/Identity-Provider/tests/mocks"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetSecurityLogListHandler_Unauthorized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogService := mocks.NewMockLogService(ctrl)
+	handler := &v1.LogHandler{
+		LogService: mockLogService,
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	c.Request, _ = http.NewRequest("GET", "/logs/security", nil)
+	// User only has "View audit logs" but NOT "View security logs"
+	c.Set("permissions", []string{"View audit logs"})
+
+	handler.GetSecurityLogList(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401, got %d", w.Code)
+	}
+}
+
+func TestGetSecurityLogListHandler_Authorized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogService := mocks.NewMockLogService(ctrl)
+	handler := &v1.LogHandler{
+		LogService: mockLogService,
+	}
+
+	actor := "test@example.com"
+	logs := []dto.PostAuditLogRequest{
+		{Actor: &actor, Action: "login", Status: "success"},
+	}
+
+	mockLogService.EXPECT().
+		GetSecurityLogListWithFilters(gomock.Any(), gomock.Any(), 10, 1).
+		Return(logs, int64(1), 1, nil)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	c.Request, _ = http.NewRequest("GET", "/logs/security", nil)
+	c.Set("permissions", []string{"View security logs"})
+
+	handler.GetSecurityLogList(c)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+}
+
+func TestGetSecurityLogHandler_Unauthorized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogService := mocks.NewMockLogService(ctrl)
+	handler := &v1.LogHandler{
+		LogService: mockLogService,
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	c.Params = []gin.Param{{Key: "id", Value: "1"}}
+	c.Request, _ = http.NewRequest("GET", "/logs/security/1", nil)
+	c.Set("permissions", []string{"View audit logs"})
+
+	handler.GetSecurityLog(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
This pull request updates the authorization logic for security log endpoints to require the correct permission and adds tests to ensure this behavior. The main changes are:

**Authorization Logic Updates:**

* Changed the permission check in `GetSecurityLogList` and `GetSecurityLog` handlers to require `"View security logs"` instead of `"View audit logs"`, ensuring only users with the appropriate permission can access security logs. [[1]](diffhunk://#diff-f5577a462334df73b3f581e40270fc1832b7172dd6e14d65d798449b2acee1eeL186-R186) [[2]](diffhunk://#diff-f5577a462334df73b3f581e40270fc1832b7172dd6e14d65d798449b2acee1eeL249-R249)

**Testing Improvements:**

* Added a new test file `backend/tests/handler/log_handler_security_test.go` with tests for the security log handlers, covering both authorized and unauthorized access scenarios.
  * Tests verify that users with only `"View audit logs"` are denied access, and users with `"View security logs"` are granted access.

These changes improve the security and correctness of the log access control.