### PR TITLE
Fix/mfa flow UI (#180)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,11 +4,6 @@ import Register from "./auth/pages/Register";
 import RegisterPasswordSetup from "./auth/pages/RegisterPasswordSetup";
 import Logout from "./auth/pages/Logout";
 import Callback from "./auth/pages/Callback";
-import Mfa from "./auth/pages/Mfa";
-import MfaAuthenticator from "./auth/pages/MfaAuthenticator";
-import MfaBackupCode from "./auth/pages/MfaBackupCode";
-import MfaSetup from "./auth/pages/MfaSetup";
-import MfaSetupConfirm from "./auth/pages/MfaSetupConfirm";
 import AuthorizeRedirect from "./auth/pages/AuthorizeRedirect";
 import ErrorPage from "./auth/pages/ErrorPage";
 import AccessDenied from "./auth/pages/AccessDenied";
@@ -37,46 +32,6 @@ export default function App() {
         <Route path="/register" element={<Register />} />
         <Route path="/register/set-password" element={<RegisterPasswordSetup />}/>
         <Route path="/callback" element={<Callback />} />
-        <Route
-          path="/mfa"
-          element={
-            <ProtectedRoute>
-              <Mfa />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/mfa/authenticator"
-          element={
-            <ProtectedRoute>
-              <MfaAuthenticator />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/mfa/backup-code"
-          element={
-            <ProtectedRoute>
-              <MfaBackupCode />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/mfa/setup"
-          element={
-            <ProtectedRoute>
-              <MfaSetup />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/mfa/setup/confirm"
-          element={
-            <ProtectedRoute>
-              <MfaSetupConfirm />
-            </ProtectedRoute>
-          }
-        />
         <Route path="/logout" element={<Logout />} />
         <Route path="/error" element={<ErrorPage />} />
         <Route path={ACCESS_DENIED_PATH} element={<AccessDenied />} />

--- a/frontend/src/auth/components/LoginForm.jsx
+++ b/frontend/src/auth/components/LoginForm.jsx
@@ -5,7 +5,7 @@ import ErrorAlert from "../../components/ErrorAlert";
 import ChangePasswordModal from "../../components/ChangePasswordModal";
 import { buildAccessDeniedPath } from "../utils/loginRoute";
 
-export default function LoginForm({ clientId, initialError = "" }) {
+export default function LoginForm({ clientId, initialError = "", onLoginSuccess }) {
   const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -132,6 +132,14 @@ export default function LoginForm({ clientId, initialError = "" }) {
 
       if (!redirectUrl) {
         setError("Invalid server response. Please contact support.");
+        return;
+      }
+
+      if (onLoginSuccess) {
+        onLoginSuccess({
+          email,
+          redirectUrl,
+        });
         return;
       }
 

--- a/frontend/src/auth/components/LoginMfaFlow.jsx
+++ b/frontend/src/auth/components/LoginMfaFlow.jsx
@@ -1,0 +1,412 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import QRCode from "qrcode";
+import { authService } from "../services/authService";
+import { clearAuthState, promotePendingMfaTokenResponse } from "../utils/authCookies";
+import { consumeMfaReturnPath, rememberMfaSetup, getMfaSetup, clearMfaSetup, rememberMfaVerified } from "../utils/mfaFlow";
+import { buildLoginPath } from "../utils/loginRoute";
+import { mfaService } from "../../services/mfaService";
+import { passwordResetService } from "../../services/passwordResetService";
+import { userService } from "../../services/userService";
+import ErrorAlert from "../../components/ErrorAlert";
+import MfaAuthenticatorCodeStep from "./mfa/MfaAuthenticatorCodeStep";
+import MfaBackupCodeStep from "./mfa/MfaBackupCodeStep";
+import MfaLoadingStep from "./mfa/MfaLoadingStep";
+import MfaSetupConfirmStep from "./mfa/MfaSetupConfirmStep";
+import MfaSetupQrStep from "./mfa/MfaSetupQrStep";
+import MfaVerifyStep from "./mfa/MfaVerifyStep";
+import { getDigits } from "./mfa/mfaInputUtils";
+
+const MFA_STEPS = {
+  CHOOSE: "choose",
+  AUTHENTICATOR: "authenticator",
+  BACKUP_CODE: "backupCode",
+  SETUP: "setup",
+  SETUP_CONFIRM: "setupConfirm",
+};
+
+function getRequestErrorMessage(error, fallbackMessage) {
+  return (
+    error?.response?.data?.error ||
+    error?.response?.data?.message ||
+    error?.message ||
+    fallbackMessage
+  );
+}
+
+export default function LoginMfaFlow({ clientId, callbackRedirectUrl = "", initialEmail = "" }) {
+  const navigate = useNavigate();
+  const [step, setStep] = useState(MFA_STEPS.CHOOSE);
+  const [email, setEmail] = useState(initialEmail);
+  const [code, setCode] = useState("");
+  const [backupCode, setBackupCode] = useState("");
+  const [mode, setMode] = useState("email");
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasSentOtp, setHasSentOtp] = useState(false);
+  const [isSendingOtp, setIsSendingOtp] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [isCheckingAuthenticators, setIsCheckingAuthenticators] = useState(false);
+  const [qrCodeUrl, setQrCodeUrl] = useState("");
+  const [setup, setSetup] = useState({ email: "", secret: "", otpAuthUri: "" });
+  const [name, setName] = useState("");
+  const [backupCodes, setBackupCodes] = useState([]);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const finishMfa = () => {
+    clearMfaSetup();
+    rememberMfaVerified();
+
+    if (callbackRedirectUrl) {
+      window.location.href = callbackRedirectUrl;
+      return;
+    }
+
+    promotePendingMfaTokenResponse();
+    navigate(consumeMfaReturnPath(), { replace: true });
+  };
+
+  const returnToLogin = async () => {
+    try {
+      const session = await authService.checkSession();
+      const userId = session?.user_id || "";
+
+      if (userId) {
+        await authService.logout({ clientId, userId });
+      }
+    } catch (logoutError) {
+      console.error("Unable to clear MFA session:", logoutError);
+    } finally {
+      clearAuthState();
+      navigate(buildLoginPath(clientId), { replace: true });
+    }
+  };
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadCurrentUser() {
+      if (initialEmail) {
+        setEmail(initialEmail);
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const currentUser = await userService.getMe();
+
+        if (isMounted) {
+          setEmail(currentUser?.email || "");
+        }
+      } catch (loadError) {
+        if (isMounted) {
+          setError(
+            getRequestErrorMessage(
+              loadError,
+              "Unable to prepare MFA. Please sign in again.",
+            ),
+          );
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    loadCurrentUser();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [initialEmail]);
+
+  const handleSendOtp = async () => {
+    setError("");
+
+    if (!email) {
+      setError("Your email address is unavailable.");
+      return;
+    }
+
+    try {
+      setIsSendingOtp(true);
+      await passwordResetService.sendOtp({ email });
+      setHasSentOtp(true);
+    } catch (otpError) {
+      setError(getRequestErrorMessage(otpError, "Unable to send an OTP right now."));
+    } finally {
+      setIsSendingOtp(false);
+    }
+  };
+
+  const handleSelectEmail = () => {
+    setStep(MFA_STEPS.CHOOSE);
+    setMode("email");
+    setCode("");
+    setError("");
+  };
+
+  const handleSelectAuthenticator = async () => {
+    setError("");
+    setCode("");
+    setMode("authenticator");
+
+    try {
+      setIsCheckingAuthenticators(true);
+      const authenticators = await mfaService.getAuthenticators(email);
+
+      if (authenticators.length === 0) {
+        await loadAuthenticatorSetup();
+        return;
+      }
+
+      setStep(MFA_STEPS.AUTHENTICATOR);
+    } catch (authenticatorError) {
+      setError(
+        getRequestErrorMessage(
+          authenticatorError,
+          "Unable to check your authenticator apps.",
+        ),
+      );
+    } finally {
+      setIsCheckingAuthenticators(false);
+    }
+  };
+
+  const loadAuthenticatorSetup = async () => {
+    setStep(MFA_STEPS.SETUP);
+    setQrCodeUrl("");
+    setError("");
+
+    try {
+      const nextSetup = await mfaService.getSetup(email);
+      const nextQrCodeUrl = await QRCode.toDataURL(nextSetup.otpAuthUri, {
+        errorCorrectionLevel: "M",
+        margin: 2,
+        width: 320,
+      });
+
+      rememberMfaSetup({ ...nextSetup, email });
+      setQrCodeUrl(nextQrCodeUrl);
+    } catch (setupError) {
+      setError(
+        getRequestErrorMessage(
+          setupError,
+          "Unable to load authenticator setup.",
+        ),
+      );
+    }
+  };
+
+  const handleVerifyEmailOtp = async (event) => {
+    event.preventDefault();
+    setError("");
+
+    if (code.length !== 6) {
+      setError("Enter the 6-digit verification code.");
+      return;
+    }
+
+    try {
+      setIsVerifying(true);
+      await passwordResetService.verifyOtp({ email, otp: code });
+      finishMfa();
+    } catch (verifyError) {
+      setError(getRequestErrorMessage(verifyError, "Unable to verify this code."));
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  const handleVerifyAuthenticator = async (event) => {
+    event.preventDefault();
+    setError("");
+
+    if (code.length !== 6) {
+      setError("Enter the 6-digit authenticator code.");
+      return;
+    }
+
+    try {
+      setIsVerifying(true);
+      await mfaService.verifyCode({ email, code });
+      finishMfa();
+    } catch (verifyError) {
+      setError(
+        getRequestErrorMessage(
+          verifyError,
+          "Unable to verify this authenticator code.",
+        ),
+      );
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  const handleVerifyBackupCode = async (event) => {
+    event.preventDefault();
+    setError("");
+
+    const normalizedBackupCode = backupCode.trim();
+
+    if (!normalizedBackupCode) {
+      setError("Enter your backup code.");
+      return;
+    }
+
+    try {
+      setIsVerifying(true);
+      await mfaService.verifyCode({ email, code: normalizedBackupCode });
+      finishMfa();
+    } catch (verifyError) {
+      setError(
+        getRequestErrorMessage(
+          verifyError,
+          "Unable to verify this backup code.",
+        ),
+      );
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  const handleOpenSetupConfirm = () => {
+    const storedSetup = getMfaSetup();
+
+    if (!storedSetup.secret) {
+      setError("Authenticator setup is unavailable. Please try again.");
+      return;
+    }
+
+    setSetup(storedSetup);
+    setCode("");
+    setStep(MFA_STEPS.SETUP_CONFIRM);
+  };
+
+  const handleSaveAuthenticator = async (event) => {
+    event.preventDefault();
+    setError("");
+
+    if (code.length !== 6) {
+      setError("Enter the 6-digit code from your authenticator app.");
+      return;
+    }
+
+    if (!name.trim()) {
+      setError("Enter the authenticator app name.");
+      return;
+    }
+
+    try {
+      setIsSaving(true);
+      const result = await mfaService.createAuthenticator({
+        email: setup.email,
+        secret: setup.secret,
+        code,
+        name,
+      });
+
+      setBackupCodes(result.backupCodes);
+    } catch (saveError) {
+      setError(
+        getRequestErrorMessage(saveError, "Unable to save this authenticator."),
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const renderStep = () => {
+    if (isLoading) {
+      return <MfaLoadingStep />;
+    }
+
+    if (step === MFA_STEPS.AUTHENTICATOR) {
+      return (
+        <MfaAuthenticatorCodeStep
+          code={code}
+          isVerifying={isVerifying}
+          onCodeChange={(value) => setCode(getDigits(value))}
+          onVerify={handleVerifyAuthenticator}
+          onUseBackupCode={() => {
+            setBackupCode("");
+            setError("");
+            setStep(MFA_STEPS.BACKUP_CODE);
+          }}
+        />
+      );
+    }
+
+    if (step === MFA_STEPS.BACKUP_CODE) {
+      return (
+        <MfaBackupCodeStep
+          backupCode={backupCode}
+          isVerifying={isVerifying}
+          onBackupCodeChange={setBackupCode}
+          onVerify={handleVerifyBackupCode}
+        />
+      );
+    }
+
+    if (step === MFA_STEPS.SETUP) {
+      return (
+        <MfaSetupQrStep
+          qrCodeUrl={qrCodeUrl}
+          isLoading={!qrCodeUrl && !error}
+          onNext={handleOpenSetupConfirm}
+        />
+      );
+    }
+
+    if (step === MFA_STEPS.SETUP_CONFIRM) {
+      return (
+        <MfaSetupConfirmStep
+          code={code}
+          name={name}
+          backupCodes={backupCodes}
+          isSaving={isSaving}
+          onCodeChange={(value) => setCode(getDigits(value))}
+          onNameChange={setName}
+          onSubmit={handleSaveAuthenticator}
+          onContinue={finishMfa}
+        />
+      );
+    }
+
+    return (
+      <MfaVerifyStep
+        email={email}
+        code={code}
+        mode={mode}
+        hasSentOtp={hasSentOtp}
+        isSendingOtp={isSendingOtp}
+        isVerifying={isVerifying}
+        isCheckingAuthenticators={isCheckingAuthenticators}
+        onSelectEmail={handleSelectEmail}
+        onSelectAuthenticator={handleSelectAuthenticator}
+        onCodeChange={(value) => setCode(getDigits(value))}
+        onSendOtp={handleSendOtp}
+        onVerify={handleVerifyEmailOtp}
+      />
+    );
+  };
+
+  return (
+    <div className="w-full max-w-[34.5rem] px-1 sm:px-0">
+      <div className="rounded-[2rem] border-[3px] border-[#a13a3a]/60 bg-[#5b0b10]/35 p-1 shadow-[0_34px_90px_-42px_rgba(0,0,0,0.95)] backdrop-blur-sm">
+        <div className="rounded-[calc(2rem-7px)] bg-[linear-gradient(180deg,rgba(122,13,21,0.72),rgba(55,6,11,0.78))] px-5 py-6 sm:px-8 sm:py-8">
+          <div className="mb-6 flex justify-center">
+            <img src="/assets/images/IDP_Logo.png" alt="Identity Provider" className="h-20 w-20 object-contain drop-shadow-[0_0_22px_rgba(248,210,78,0.5)]" />
+          </div>
+
+          <div className="mb-5">
+            <ErrorAlert message={error} onClose={() => setError("")} />
+          </div>
+
+          {renderStep()}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/auth/components/LoginMfaFlow.jsx
+++ b/frontend/src/auth/components/LoginMfaFlow.jsx
@@ -1,10 +1,8 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import QRCode from "qrcode";
-import { authService } from "../services/authService";
-import { clearAuthState, promotePendingMfaTokenResponse } from "../utils/authCookies";
+import { promotePendingMfaTokenResponse } from "../utils/authCookies";
 import { consumeMfaReturnPath, rememberMfaSetup, getMfaSetup, clearMfaSetup, rememberMfaVerified } from "../utils/mfaFlow";
-import { buildLoginPath } from "../utils/loginRoute";
 import { mfaService } from "../../services/mfaService";
 import { passwordResetService } from "../../services/passwordResetService";
 import { userService } from "../../services/userService";
@@ -34,7 +32,7 @@ function getRequestErrorMessage(error, fallbackMessage) {
   );
 }
 
-export default function LoginMfaFlow({ clientId, callbackRedirectUrl = "", initialEmail = "" }) {
+export default function LoginMfaFlow({ callbackRedirectUrl = "", initialEmail = "" }) {
   const navigate = useNavigate();
   const [step, setStep] = useState(MFA_STEPS.CHOOSE);
   const [email, setEmail] = useState(initialEmail);
@@ -64,22 +62,6 @@ export default function LoginMfaFlow({ clientId, callbackRedirectUrl = "", initi
 
     promotePendingMfaTokenResponse();
     navigate(consumeMfaReturnPath(), { replace: true });
-  };
-
-  const returnToLogin = async () => {
-    try {
-      const session = await authService.checkSession();
-      const userId = session?.user_id || "";
-
-      if (userId) {
-        await authService.logout({ clientId, userId });
-      }
-    } catch (logoutError) {
-      console.error("Unable to clear MFA session:", logoutError);
-    } finally {
-      clearAuthState();
-      navigate(buildLoginPath(clientId), { replace: true });
-    }
   };
 
   useEffect(() => {

--- a/frontend/src/auth/components/ProtectedRoute.jsx
+++ b/frontend/src/auth/components/ProtectedRoute.jsx
@@ -6,7 +6,7 @@ import { buildAccessDeniedPath, buildLoginPath } from "../utils/loginRoute";
 import { userService } from "../../services/userService";
 import { hasAssignedRoles } from "../utils/authAccess";
 import { hasStoredAuthTokens } from "../utils/authRecovery";
-import { hasMfaVerified, isMfaPath, MFA_PATH, rememberMfaReturnPath } from "../utils/mfaFlow";
+import { hasMfaVerified, isMfaPath, rememberMfaReturnPath } from "../utils/mfaFlow";
 
 export default function ProtectedRoute({ children }) {
   const [authState, setAuthState] = useState("loading");
@@ -106,7 +106,7 @@ export default function ProtectedRoute({ children }) {
   }
 
   if (authState === "needs-mfa") {
-    return <Navigate to={MFA_PATH} replace />;
+    return <Navigate to={buildLoginPath(undefined, { showMfa: true })} replace />;
   }
 
   return children;

--- a/frontend/src/auth/components/RegisterForm.jsx
+++ b/frontend/src/auth/components/RegisterForm.jsx
@@ -931,7 +931,10 @@ export default function RegisterForm({ clientId }) {
   const maskedEmail = details.email ? maskEmail(details.email) : "";
 
   return (
-    <div className="relative z-20 w-full max-w-[38rem] px-1 sm:px-0">
+    <div className={`relative z-20 w-full max-w-[38rem] px-1 sm:px-0 ${
+        step === "success" ? "lg:mt-24 xl:mt-28" : ""
+      }`}
+    >
       <div className="rounded-[2rem] border-[3px] border-[#a13a3a]/60 bg-[#5b0b10]/35 p-1 shadow-[0_32px_80px_-42px_rgba(0,0,0,0.95)] backdrop-blur-sm">
         <div className="rounded-[calc(2rem-7px)] bg-[linear-gradient(180deg,rgba(122,13,21,0.72),rgba(55,6,11,0.78))] px-6 py-6 sm:px-9 lg:px-10">
           <div className="space-y-5">

--- a/frontend/src/auth/components/RegisterPasswordSetupForm.jsx
+++ b/frontend/src/auth/components/RegisterPasswordSetupForm.jsx
@@ -222,16 +222,14 @@ export default function RegisterPasswordSetupForm({ clientId, email = "", invita
 
   return (
     <div className="relative z-20 w-full max-w-[34rem] px-1 sm:px-0">
-      <div className="rounded-4xl border border-white/20 bg-white/10 p-1 shadow-[0_32px_80px_-42px_rgba(0,0,0,0.95)] backdrop-blur-2xl">
-        <div className="rounded-[calc(2rem-4px)] bg-[linear-gradient(180deg,rgba(120,12,22,0.72),rgba(60,7,12,0.86))] px-6 py-7 sm:px-8 sm:py-8">
+      <div className="rounded-[2rem] border-[3px] border-[#a13a3a]/60 bg-[#5b0b10]/35 p-1 shadow-[0_34px_90px_-42px_rgba(0,0,0,0.95)] backdrop-blur-sm">
+        <div className="rounded-[calc(2rem-7px)] bg-[linear-gradient(180deg,rgba(122,13,21,0.72),rgba(55,6,11,0.78))] px-6 py-7 sm:px-8 sm:py-8">
           {isComplete ? (
             <PasswordSavedState loginPath={loginPath} />
           ) : (
             <div className="space-y-6">
               <div className="space-y-4 text-center">
-                <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-white/15 text-[#f8d24e] shadow-[0_20px_45px_-28px_rgba(248,210,78,0.55)]">
-                  <PasswordIcon />
-                </div>
+                <img src="/assets/images/IDP_Logo.png" alt="IDP Logo" className="float-logo mx-auto block h-20 object-contain drop-shadow-[0_0_22px_rgba(248,210,78,0.5)]" />
 
                 <div className="space-y-2">
                   <h2 className="text-3xl font-bold leading-tight text-white">
@@ -336,9 +334,7 @@ export default function RegisterPasswordSetupForm({ clientId, email = "", invita
 function PasswordSavedState({ loginPath }) {
   return (
     <div className="space-y-5 text-center">
-      <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-emerald-100 text-emerald-600 shadow-[0_20px_45px_-28px_rgba(16,185,129,0.6)]">
-        <CheckIcon />
-      </div>
+      <img src="/assets/images/IDP_Logo.png" alt="IDP Logo" className="float-logo mx-auto block h-20 object-contain drop-shadow-[0_0_22px_rgba(248,210,78,0.5)]" />
 
       <div className="space-y-2">
         <h2 className="text-3xl font-bold leading-tight text-white">

--- a/frontend/src/auth/components/RegisterPasswordSetupForm.jsx
+++ b/frontend/src/auth/components/RegisterPasswordSetupForm.jsx
@@ -369,14 +369,6 @@ function EmailIcon() {
   );
 }
 
-function CheckIcon() {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" className="h-10 w-10">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m9 12 2 2 4-4m6 2a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
-    </svg>
-  );
-}
-
 function EyeIcon() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/frontend/src/auth/components/mfa/MfaAuthenticatorCodeStep.jsx
+++ b/frontend/src/auth/components/mfa/MfaAuthenticatorCodeStep.jsx
@@ -1,8 +1,6 @@
-import { Link } from "react-router-dom";
-import { MFA_BACKUP_CODE_PATH } from "../../utils/mfaFlow";
 import MfaCodeInput from "./MfaCodeInput";
 
-export default function MfaAuthenticatorCodeStep({ code, isVerifying, onCodeChange, onVerify }) {
+export default function MfaAuthenticatorCodeStep({ code, isVerifying, onCodeChange, onVerify, onUseBackupCode }) {
   return (
     <div className="space-y-6">
       <div className="space-y-2 text-center">
@@ -23,12 +21,14 @@ export default function MfaAuthenticatorCodeStep({ code, isVerifying, onCodeChan
         </button>
       </form>
 
-      <p className="text-center text-sm text-white/72">
-        Lost your authenticator app, use{" "}
-        <Link to={MFA_BACKUP_CODE_PATH} className="font-semibold text-[#ffd700] underline decoration-transparent transition hover:decoration-[#ffd700]">
-          Backup Code
-        </Link>
-      </p>
+      {onUseBackupCode ? (
+        <p className="text-center text-sm text-white/72">
+          Lost your authenticator app, use{" "}
+          <button type="button" onClick={onUseBackupCode} className="font-semibold text-[#ffd700] underline decoration-transparent transition hover:decoration-[#ffd700]">
+            Backup Code
+          </button>
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/auth/components/mfa/MfaCodeInput.jsx
+++ b/frontend/src/auth/components/mfa/MfaCodeInput.jsx
@@ -3,7 +3,16 @@ import { getDigits } from "./mfaInputUtils";
 
 export default function MfaCodeInput({ value, onChange, disabled = false }) {
   const inputsRef = useRef([]);
-  const digits = value.padEnd(6, " ").split("").slice(0, 6);
+  const digits = Array.from({ length: 6 }, (_, index) => value[index] ?? "");
+
+  const updateDigits = (nextDigits) => {
+    onChange(nextDigits.join(""));
+  };
+
+  const focusInput = (index) => {
+    inputsRef.current[index]?.focus();
+    inputsRef.current[index]?.select();
+  };
 
   useEffect(() => {
     if (!disabled) {
@@ -23,18 +32,81 @@ export default function MfaCodeInput({ value, onChange, disabled = false }) {
           disabled={disabled}
           value={digit.trim()}
           onChange={(event) => {
-            const nextDigits = [...digits];
-            nextDigits[index] = getDigits(event.target.value).slice(-1);
-            onChange(nextDigits.join("").replace(/\s/g, ""));
+            const pastedDigits = getDigits(event.target.value);
 
-            if (nextDigits[index] && index < 5) {
-              inputsRef.current[index + 1]?.focus();
+            if (!pastedDigits) {
+              return;
             }
+
+            const nextDigits = [...digits];
+            pastedDigits.split("").forEach((nextDigit, offset) => {
+              const nextIndex = index + offset;
+
+              if (nextIndex < nextDigits.length) {
+                nextDigits[nextIndex] = nextDigit;
+              }
+            });
+
+            updateDigits(nextDigits);
+            focusInput(Math.min(index + pastedDigits.length, 5));
           }}
           onKeyDown={(event) => {
-            if (event.key === "Backspace" && !digits[index] && index > 0) {
-              inputsRef.current[index - 1]?.focus();
+            if (event.key === "Backspace") {
+              event.preventDefault();
+              const nextDigits = [...digits];
+
+              if (nextDigits[index]) {
+                nextDigits[index] = "";
+                updateDigits(nextDigits);
+                return;
+              }
+
+              if (index > 0) {
+                nextDigits[index - 1] = "";
+                updateDigits(nextDigits);
+                focusInput(index - 1);
+              }
+              return;
             }
+
+            if (event.key === "Delete") {
+              event.preventDefault();
+              const nextDigits = [...digits];
+              nextDigits[index] = "";
+              updateDigits(nextDigits);
+              return;
+            }
+
+            if (event.key === "ArrowLeft" && index > 0) {
+              event.preventDefault();
+              focusInput(index - 1);
+              return;
+            }
+
+            if (event.key === "ArrowRight" && index < 5) {
+              event.preventDefault();
+              focusInput(index + 1);
+            }
+          }}
+          onPaste={(event) => {
+            event.preventDefault();
+            const pastedDigits = getDigits(event.clipboardData.getData("text"));
+
+            if (!pastedDigits) {
+              return;
+            }
+
+            const nextDigits = [...digits];
+            pastedDigits.split("").forEach((nextDigit, offset) => {
+              const nextIndex = index + offset;
+
+              if (nextIndex < nextDigits.length) {
+                nextDigits[nextIndex] = nextDigit;
+              }
+            });
+
+            updateDigits(nextDigits);
+            focusInput(Math.min(index + pastedDigits.length, 5));
           }}
           className="h-12 w-10 rounded-xl border border-white/20 bg-white/95 text-center text-lg font-semibold text-[#351018] outline-none transition focus:border-[#ffd700] focus:ring-4 focus:ring-[#ffd700]/20 disabled:cursor-not-allowed disabled:opacity-60 sm:h-14 sm:w-12"
           maxLength={1}

--- a/frontend/src/auth/components/mfa/MfaSetupConfirmStep.jsx
+++ b/frontend/src/auth/components/mfa/MfaSetupConfirmStep.jsx
@@ -4,6 +4,7 @@ import MfaCodeInput from "./MfaCodeInput";
 export default function MfaSetupConfirmStep({ code, name, backupCodes, isSaving, onCodeChange, onNameChange, onSubmit, onContinue }) {
   const hasBackupCodes = backupCodes.length > 0;
   const [copyStatus, setCopyStatus] = useState("");
+  const [hasCopiedBackupCodes, setHasCopiedBackupCodes] = useState(false);
 
   const handleCopyBackupCodes = async () => {
     const backupCodesText = backupCodes.join("\n");
@@ -14,6 +15,7 @@ export default function MfaSetupConfirmStep({ code, name, backupCodes, isSaving,
 
     try {
       await navigator.clipboard.writeText(backupCodesText);
+      setHasCopiedBackupCodes(true);
       setCopyStatus("Copied");
       window.setTimeout(() => setCopyStatus(""), 1600);
     } catch (error) {
@@ -40,7 +42,7 @@ export default function MfaSetupConfirmStep({ code, name, backupCodes, isSaving,
                 </svg>
               </div>
               <p className="text-sm font-medium leading-6">
-                Copy or save these backup codes before continuing. Use them if your authenticator app is lost. Each backup code can only be used once.
+                Save these backup codes before continuing. Use them if you lose access to your authenticator app. Each code can only be used once.
               </p>
             </div>
           </div>
@@ -48,28 +50,36 @@ export default function MfaSetupConfirmStep({ code, name, backupCodes, isSaving,
           <div className="rounded-2xl border border-emerald-300/20 bg-emerald-950/25 p-4 text-white">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <h2 className="font-semibold text-emerald-100">Backup codes</h2>
-              <button type="button" onClick={handleCopyBackupCodes} aria-label={copyStatus === "Copied" ? "Backup codes copied" : "Copy backup codes"} title={copyStatus === "Copied" ? "Copied" : "Copy codes"} className="btn h-10 w-10 rounded-xl border border-emerald-300/25 bg-white/10 p-0 text-emerald-50 shadow-none transition hover:border-emerald-200/50 hover:bg-white/15">
-                {copyStatus === "Copied" ? (
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+              <button type="button" onClick={handleCopyBackupCodes} aria-label={copyStatus === "Copied" ? "Backup codes copied" : "Copy backup codes"} title={copyStatus === "Copied" ? "Copied" : "Copy codes"} className="btn relative h-10 w-10 overflow-hidden rounded-xl border border-emerald-300/25 bg-white/10 p-0 text-emerald-50 shadow-none transition duration-300 hover:border-emerald-200/50 hover:bg-white/15">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`absolute size-6 transition-all duration-300 ${copyStatus === "Copied" ? "scale-100 opacity-100" : "scale-75 opacity-0"}`}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M11.35 3.836c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m8.9-4.414c.376.023.75.05 1.124.08 1.131.094 1.976 1.057 1.976 2.192V16.5A2.25 2.25 0 0 1 18 18.75h-2.25m-7.5-10.5H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V18.75m-7.5-10.5h6.375c.621 0 1.125.504 1.125 1.125v9.375m-8.25-3 1.5 1.5 3-3.75" />
-                  </svg>
-                ) : (
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+                </svg>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`absolute size-6 transition-all duration-300 ${copyStatus === "Copied" ? "scale-75 opacity-0" : "scale-100 opacity-100"}`}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25ZM6.75 12h.008v.008H6.75V12Zm0 3h.008v.008H6.75V15Zm0 3h.008v.008H6.75V18Z" />
-                  </svg>
-                )}
+                </svg>
               </button>
             </div>
 
             <div className="mt-4 rounded-xl border border-white/10 bg-black/14 p-4">
-              <pre className="whitespace-pre-wrap break-all font-mono text-sm leading-7 text-white/90">
-                {backupCodes.join("\n")}
-              </pre>
+              <div className="grid grid-cols-3 gap-2">
+                {backupCodes.map((backupCode) => (
+                  <span key={backupCode} className="rounded-lg border border-white/10 bg-white/5 px-2 py-2 text-center font-mono text-xs font-semibold text-white/90">
+                    {backupCode}
+                  </span>
+                ))}
+              </div>
             </div>
           </div>
         </div>
       ) : (
         <form onSubmit={onSubmit} className="space-y-5">
+          <div>
+            <label className="mb-2 block text-sm font-medium text-white/90">
+              Authenticator Name
+            </label>
+            <input type="text" value={name} onChange={(event) => onNameChange(event.target.value)} placeholder="Enter the App Name(e.g., Google Auth)" className="h-13 w-full rounded-2xl border border-white/20 bg-white/95 px-4 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-[#ffd700] focus:ring-4 focus:ring-[#ffd700]/20"/>
+          </div>
+
           <div className="space-y-3">
             <label className="block text-sm font-medium text-white/90">
               Authenticator code
@@ -81,13 +91,6 @@ export default function MfaSetupConfirmStep({ code, name, backupCodes, isSaving,
             />
           </div>
 
-          <div>
-            <label className="mb-2 block text-sm font-medium text-white/90">
-              Authenticator app name
-            </label>
-            <input type="text" value={name} onChange={(event) => onNameChange(event.target.value)} placeholder="Google Authenticator" className="h-13 w-full rounded-2xl border border-white/20 bg-white/95 px-4 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-[#ffd700] focus:ring-4 focus:ring-[#ffd700]/20"/>
-          </div>
-
           <button type="submit" disabled={isSaving} className="btn h-12 w-full rounded-lg border-[#ffd700] bg-[#ffd700] text-[#991b1b] transition hover:border-[#991b1b] hover:bg-[#991b1b] hover:text-white disabled:cursor-not-allowed disabled:opacity-60">
             {isSaving ? "Saving..." : "Save Authenticator"}
           </button>
@@ -95,7 +98,7 @@ export default function MfaSetupConfirmStep({ code, name, backupCodes, isSaving,
       )}
 
       {hasBackupCodes ? (
-        <button type="button" onClick={onContinue} className="btn h-12 w-full rounded-lg border-[#ffd700] bg-[#ffd700] text-[#991b1b] transition hover:border-[#991b1b] hover:bg-[#991b1b] hover:text-white">
+        <button type="button" onClick={onContinue} disabled={!hasCopiedBackupCodes} className="btn h-12 w-full rounded-lg border-[#ffd700] bg-[#ffd700] text-[#991b1b] transition hover:border-[#991b1b] hover:bg-[#991b1b] hover:text-white disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/10 disabled:text-white/40">
           Continue
         </button>
       ) : null}

--- a/frontend/src/auth/components/mfa/MfaVerifyStep.jsx
+++ b/frontend/src/auth/components/mfa/MfaVerifyStep.jsx
@@ -68,7 +68,7 @@ export default function MfaVerifyStep({ email, code, mode, hasSentOtp, isSending
             <span className="block font-semibold">Passkey</span>
           </span>
           <span className="rounded-full border border-white/10 px-3 py-1 text-xs">
-            Disabled
+            Not Available
           </span>
         </button>
 
@@ -88,9 +88,11 @@ export default function MfaVerifyStep({ email, code, mode, hasSentOtp, isSending
         </button>
       </div>
 
-      <button type="button" onClick={onCancel} className="h-11 w-full rounded-lg border border-white/18 bg-white/8 text-sm font-semibold text-white/80 transition hover:border-[#ffd700]/55 hover:bg-[#ffd700]/12 hover:text-white">
-        Back to login
-      </button>
+      {onCancel ? (
+        <button type="button" onClick={onCancel} className="h-11 w-full rounded-lg border border-white/18 bg-white/8 text-sm font-semibold text-white/80 transition hover:border-[#ffd700]/55 hover:bg-[#ffd700]/12 hover:text-white">
+          Back to login
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/auth/pages/Callback.jsx
+++ b/frontend/src/auth/pages/Callback.jsx
@@ -1,10 +1,9 @@
 import { useEffect, useRef } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { authService } from "../services/authService";
-import { storePendingMfaTokenResponse } from "../utils/authCookies";
+import { storeTokenResponse } from "../utils/authCookies";
 import { buildAccessDeniedPath, buildLoginPath } from "../utils/loginRoute";
 import { clearAuthorizeAttempt, clearAuthorizeReturnPath, consumeAuthorizeReturnPath } from "../utils/authorizeFlow";
-import { clearMfaVerified, MFA_PATH, rememberMfaReturnPath } from "../utils/mfaFlow";
 
 export default function Callback() {
   const [searchParams] = useSearchParams();
@@ -32,15 +31,13 @@ export default function Callback() {
           throw new Error("Token exchange did not return an access token.");
         }
 
-        storePendingMfaTokenResponse(tokenResponse);
+        storeTokenResponse(tokenResponse);
         clearAuthorizeAttempt();
-        clearMfaVerified();
         sessionStorage.removeItem("termsAccepted");
         const returnPath = consumeAuthorizeReturnPath();
-        rememberMfaReturnPath(returnPath);
 
         setTimeout(() => {
-          navigate(MFA_PATH, { replace: true });
+          navigate(returnPath, { replace: true });
         }, 1000);
       } catch (err) {
         console.error(err);

--- a/frontend/src/auth/pages/Login.jsx
+++ b/frontend/src/auth/pages/Login.jsx
@@ -2,8 +2,9 @@ import { useEffect, useState } from "react";
 import { Navigate, useNavigate, useSearchParams } from "react-router-dom";
 import AuthLayout from "../layouts/AuthLayout";
 import LoginForm from "../components/LoginForm";
+import LoginMfaFlow from "../components/LoginMfaFlow";
 import AccessDenied from "./AccessDenied";
-import { buildLoginPath, getLoginClientId, getLoginErrorCode, getLoginErrorMessage, LOGIN_ERROR_CODES } from "../utils/loginRoute";
+import { buildLoginPath, getLoginClientId, getLoginErrorCode, getLoginErrorMessage, isLoginMfaRequested, LOGIN_ERROR_CODES } from "../utils/loginRoute";
 import { DEFAULT_AUTHENTICATED_PATH } from "../utils/authAccess";
 import { hasStoredAccessToken } from "../utils/authRecovery";
 
@@ -16,12 +17,14 @@ export default function Login() {
   const loginErrorMessage = isAccessDeniedError
     ? ""
     : getLoginErrorMessage(searchParams);
+  const [mfaContext, setMfaContext] = useState(null);
+  const shouldShowMfa = Boolean(mfaContext) || isLoginMfaRequested(searchParams);
   const [isResolvingAccess, setIsResolvingAccess] = useState(
-    Boolean(clientId) && !loginErrorCode,
+    Boolean(clientId) && !loginErrorCode && !shouldShowMfa,
   );
 
   useEffect(() => {
-    if (!clientId || loginErrorCode) {
+    if (!clientId || loginErrorCode || shouldShowMfa) {
       setIsResolvingAccess(false);
       return;
     }
@@ -32,7 +35,7 @@ export default function Login() {
     }
 
     setIsResolvingAccess(false);
-  }, [clientId, loginErrorCode, navigate]);
+  }, [clientId, loginErrorCode, navigate, shouldShowMfa]);
 
   if (isAccessDeniedError) {
     return <AccessDenied />;
@@ -69,7 +72,19 @@ export default function Login() {
 
   return (
     <AuthLayout>
-      <LoginForm clientId={clientId} initialError={loginErrorMessage} />
+      {shouldShowMfa ? (
+        <LoginMfaFlow
+          clientId={clientId}
+          callbackRedirectUrl={mfaContext?.redirectUrl || ""}
+          initialEmail={mfaContext?.email || ""}
+        />
+      ) : (
+        <LoginForm
+          clientId={clientId}
+          initialError={loginErrorMessage}
+          onLoginSuccess={setMfaContext}
+        />
+      )}
     </AuthLayout>
   );
 }

--- a/frontend/src/auth/pages/RegisterPasswordSetup.jsx
+++ b/frontend/src/auth/pages/RegisterPasswordSetup.jsx
@@ -5,21 +5,6 @@ import RegisterPasswordSetupForm from "../components/RegisterPasswordSetupForm";
 import { isInvitationForbiddenError, registrationActivationService } from "../services/registrationActivationService";
 import { buildLoginPath, getLoginClientId } from "../utils/loginRoute";
 
-const infoCards = [
-  {
-    title: "Invitation-based activation",
-    description:
-      "This screen is used when a secure invitation link is opened from email.",
-    icon: <LinkIcon />,
-  },
-  {
-    title: "Finish account setup",
-    description:
-      "Create your password here so the invited account can move into the normal sign-in flow.",
-    icon: <ShieldIcon />,
-  },
-];
-
 const VALIDATION_STATE = Object.freeze({
   CHECKING: "checking",
   READY: "ready",
@@ -93,56 +78,20 @@ export default function RegisterPasswordSetup() {
 
   return (
     <AuthLayout>
-      <div className="grid w-full items-center gap-10 xl:grid-cols-[minmax(0,1.05fr)_minmax(26rem,34rem)] xl:gap-14">
-        <section className="hidden xl:flex xl:flex-col xl:gap-8 xl:pr-8">
-          <div className="inline-flex w-fit items-center rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-medium uppercase tracking-[0.18em] text-white/90 backdrop-blur-xl">
-            Account Activation
-          </div>
-
-          <div className="max-w-xl space-y-4">
-            <h1 className="text-5xl font-semibold leading-tight text-white 2xl:text-6xl">
-              Set Your Password
-            </h1>
-            <p className="max-w-lg text-lg leading-8 text-white/70">
-              Invited users finish account setup here through the secure link
-              sent by email.
-            </p>
-          </div>
-
-          <div className="grid max-w-2xl gap-4 lg:grid-cols-2">
-            {infoCards.map((card) => (
-              <article key={card.title} className="group rounded-[1.75rem] border border-white/20 bg-white/10 p-5 shadow-[0_24px_55px_-35px_rgba(0,0,0,0.9)] backdrop-blur-xl transition duration-300 hover:-translate-y-1.5 hover:border-[#f8d24e]/40 hover:bg-white/20">
-                <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-[#f8d24e]/20 text-[#ffd700] transition duration-300 group-hover:scale-105 group-hover:bg-[#f8d24e]/25">
-                  {card.icon}
-                </div>
-                <h2 className="text-xl font-semibold text-white">
-                  {card.title}
-                </h2>
-                <p className="mt-2 text-sm leading-7 text-white/70">
-                  {card.description}
-                </p>
-              </article>
-            ))}
-          </div>
-        </section>
-
-        <section className="flex w-full justify-center xl:justify-end">
-          {validationState === VALIDATION_STATE.READY ? (
-            <RegisterPasswordSetupForm
-              clientId={clientId}
-              email={email}
-              invitationCode={invitationCode}
-              onInvalidInvitation={handleInvalidInvitation}
-            />
-          ) : (
-            <InvitationGateCard
-              state={validationState}
-              errorMessage={validationError}
-              loginPath={loginPath}
-            />
-          )}
-        </section>
-      </div>
+      {validationState === VALIDATION_STATE.READY ? (
+        <RegisterPasswordSetupForm
+          clientId={clientId}
+          email={email}
+          invitationCode={invitationCode}
+          onInvalidInvitation={handleInvalidInvitation}
+        />
+      ) : (
+        <InvitationGateCard
+          state={validationState}
+          errorMessage={validationError}
+          loginPath={loginPath}
+        />
+      )}
     </AuthLayout>
   );
 }
@@ -163,12 +112,10 @@ function InvitationGateCard({ state = VALIDATION_STATE.CHECKING, errorMessage = 
 
   return (
     <div className="relative z-20 w-full max-w-[34rem] px-1 sm:px-0">
-      <div className="rounded-4xl border border-white/20 bg-white/10 p-1 shadow-[0_32px_80px_-42px_rgba(0,0,0,0.95)] backdrop-blur-2xl">
-        <div className="rounded-[calc(2rem-4px)] bg-[linear-gradient(180deg,rgba(120,12,22,0.72),rgba(60,7,12,0.86))] px-6 py-7 sm:px-8 sm:py-8">
+      <div className="rounded-[2rem] border-[3px] border-[#a13a3a]/60 bg-[#5b0b10]/35 p-1 shadow-[0_34px_90px_-42px_rgba(0,0,0,0.95)] backdrop-blur-sm">
+        <div className="rounded-[calc(2rem-7px)] bg-[linear-gradient(180deg,rgba(122,13,21,0.72),rgba(55,6,11,0.78))] px-6 py-7 sm:px-8 sm:py-8">
           <div className="space-y-6 text-center">
-            <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-white/15 text-[#f8d24e] shadow-[0_20px_45px_-28px_rgba(248,210,78,0.55)]">
-              {isChecking ? <LoaderIcon /> : <LockIcon />}
-            </div>
+            <img src="/assets/images/IDP_Logo.png" alt="IDP Logo" className="float-logo mx-auto block h-20 object-contain drop-shadow-[0_0_22px_rgba(248,210,78,0.5)]" />
 
             <div className="space-y-2">
               <h2 className="text-3xl font-bold leading-tight text-white">
@@ -188,38 +135,5 @@ function InvitationGateCard({ state = VALIDATION_STATE.CHECKING, errorMessage = 
         </div>
       </div>
     </div>
-  );
-}
-
-function LinkIcon() {
-  return (
-    <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8" d="M13.19 8.688a4.5 4.5 0 0 1 6.364 6.364l-3 3a4.5 4.5 0 0 1-6.364 0m3-12.728a4.5 4.5 0 0 0-6.364 0l-3 3a4.5 4.5 0 0 0 0 6.364m4.243-1.414 7.072-7.072"/>
-    </svg>
-  );
-}
-
-function ShieldIcon() {
-  return (
-    <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.8" d="M12 3.75 5.25 6.75v5.063c0 3.902 2.527 7.356 6.25 8.438 3.723-1.082 6.25-4.536 6.25-8.438V6.75L12 3.75Zm-1.25 8.75 1.5 1.5 3-3"/>
-    </svg>
-  );
-}
-
-function LoaderIcon() {
-  return (
-    <svg className="h-8 w-8 animate-spin" viewBox="0 0 24 24" fill="none">
-      <circle cx="12" cy="12" r="9" className="stroke-white/25" strokeWidth="2.5" />
-      <path d="M21 12a9 9 0 0 0-9-9" className="stroke-current" strokeWidth="2.5" strokeLinecap="round" />
-    </svg>
-  );
-}
-
-function LockIcon() {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="size-6">
-      <path fillRule="evenodd" d="M12 1.5a5.25 5.25 0 0 0-5.25 5.25v3a3 3 0 0 0-3 3v6.75a3 3 0 0 0 3 3h10.5a3 3 0 0 0 3-3v-6.75a3 3 0 0 0-3-3v-3c0-2.9-2.35-5.25-5.25-5.25Zm3.75 8.25v-3a3.75 3.75 0 1 0-7.5 0v3h7.5Z" clipRule="evenodd" />
-    </svg>
   );
 }

--- a/frontend/src/auth/utils/loginRoute.js
+++ b/frontend/src/auth/utils/loginRoute.js
@@ -1,5 +1,6 @@
 const defaultClientId = import.meta.env.VITE_CLIENT_ID ?? "";
 const LOGIN_ERROR_QUERY_PARAM = "auth_error";
+const LOGIN_MFA_QUERY_PARAM = "mfa";
 export const LOGIN_PATH = "/login";
 export const ACCESS_DENIED_PATH = "/access-denied";
 export const LEGACY_UNAUTHORIZED_PATH = "/unauthorized";
@@ -14,7 +15,7 @@ const LOGIN_ERROR_MESSAGES = {
 };
 
 export function buildLoginPath(clientId = defaultClientId, options = {}) {
-  const { authError = "" } = options;
+  const { authError = "", showMfa = false } = options;
 
   if (authError === LOGIN_ERROR_CODES.UNAUTHORIZED) {
     return buildAccessDeniedPath(clientId);
@@ -28,6 +29,10 @@ export function buildLoginPath(clientId = defaultClientId, options = {}) {
 
   if (authError) {
     params.set(LOGIN_ERROR_QUERY_PARAM, authError);
+  }
+
+  if (showMfa) {
+    params.set(LOGIN_MFA_QUERY_PARAM, "1");
   }
 
   const queryString = params.toString();
@@ -85,4 +90,8 @@ export function getLoginErrorMessageByCode(errorCode = "") {
 
 export function getLoginErrorMessage(searchParams) {
   return getLoginErrorMessageByCode(getLoginErrorCode(searchParams));
+}
+
+export function isLoginMfaRequested(searchParams) {
+  return searchParams.get(LOGIN_MFA_QUERY_PARAM) === "1";
 }

--- a/frontend/src/components/OtpVerificationStep.jsx
+++ b/frontend/src/components/OtpVerificationStep.jsx
@@ -59,23 +59,79 @@ export default function OtpVerificationStep({ otp, setOtp, timer, canResend, onR
     : "font-mono text-[#7b0d15] transition-colors duration-500 ease-out";
 
   const handleChange = (index, value) => {
-    if (!/^\d?$/.test(value)) {
+    const digits = value.replace(/\D/g, "");
+
+    if (!digits) {
       return;
     }
 
     const updatedOtp = [...otp];
-    updatedOtp[index] = value;
+    digits.split("").forEach((digit, offset) => {
+      const nextIndex = index + offset;
+
+      if (nextIndex < updatedOtp.length) {
+        updatedOtp[nextIndex] = digit;
+      }
+    });
+
     setOtp(updatedOtp);
 
-    if (value && index < 5) {
-      inputsRef.current[index + 1]?.focus();
-    }
+    const nextFocusIndex = Math.min(index + digits.length, otp.length - 1);
+    inputsRef.current[nextFocusIndex]?.focus();
+    inputsRef.current[nextFocusIndex]?.select();
   };
 
   const handleKeyDown = (index, event) => {
-    if (event.key === "Backspace" && !otp[index] && index > 0) {
-      inputsRef.current[index - 1]?.focus();
+    if (event.key === "Backspace") {
+      event.preventDefault();
+      const updatedOtp = [...otp];
+
+      if (updatedOtp[index]) {
+        updatedOtp[index] = "";
+        setOtp(updatedOtp);
+        return;
+      }
+
+      if (index > 0) {
+        updatedOtp[index - 1] = "";
+        setOtp(updatedOtp);
+        inputsRef.current[index - 1]?.focus();
+        inputsRef.current[index - 1]?.select();
+      }
+      return;
     }
+
+    if (event.key === "Delete") {
+      event.preventDefault();
+      const updatedOtp = [...otp];
+      updatedOtp[index] = "";
+      setOtp(updatedOtp);
+      return;
+    }
+
+    if (event.key === "ArrowLeft" && index > 0) {
+      event.preventDefault();
+      inputsRef.current[index - 1]?.focus();
+      inputsRef.current[index - 1]?.select();
+      return;
+    }
+
+    if (event.key === "ArrowRight" && index < otp.length - 1) {
+      event.preventDefault();
+      inputsRef.current[index + 1]?.focus();
+      inputsRef.current[index + 1]?.select();
+    }
+  };
+
+  const handlePaste = (index, event) => {
+    event.preventDefault();
+    const digits = event.clipboardData.getData("text").replace(/\D/g, "");
+
+    if (!digits) {
+      return;
+    }
+
+    handleChange(index, digits);
   };
 
   useEffect(() => {
@@ -115,9 +171,11 @@ export default function OtpVerificationStep({ otp, setOtp, timer, canResend, onR
                     inputsRef.current[index] = element;
                   }}
                   type="text"
+                  inputMode="numeric"
                   value={digit}
                   onChange={(event) => handleChange(index, event.target.value)}
                   onKeyDown={(event) => handleKeyDown(index, event)}
+                  onPaste={(event) => handlePaste(index, event)}
                   className={`${otpInputClassName} ${otpInputErrorClassName}`}
                   maxLength={1}
                 />

--- a/frontend/src/components/profile/AuthenticatorsPanel.jsx
+++ b/frontend/src/components/profile/AuthenticatorsPanel.jsx
@@ -117,22 +117,13 @@ export default function AuthenticatorsPanel({ email = "", colorMode = "light" })
     <>
       <section className={wrapperClassName}>
         <div className="space-y-5">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
             <div>
               <h3 className={headingClassName}>Authenticator Apps</h3>
               <p className={`mt-1 ${bodyTextClassName}`}>
                 Manage the authenticator apps connected to your account.
               </p>
             </div>
-            <button type="button" onClick={loadAuthenticators} disabled={isLoading}
-              className={`btn h-10 rounded-xl px-4 text-sm shadow-none ${
-                isDarkMode
-                  ? "border border-white/12 bg-[rgba(255,248,243,0.05)] text-[#f4eaea] hover:border-[#f8d24e]/45 hover:bg-[#f8d24e]/12"
-                  : "border border-[#7b0d15]/15 bg-white text-[#7b0d15] hover:border-[#f8d24e]/70 hover:bg-[#fff4dc]"
-              }`}
-            >
-              {isLoading ? "Loading..." : "Refresh"}
-            </button>
           </div>
 
           <ErrorAlert message={error} onClose={() => setError("")} />


### PR DESCRIPTION
* remove standalone MFA page routes

* add mfa query param support to buildLoginPath and expose isLoginMfaRequested helper for triggering MFA flow via URL

* integrate inline MFA flow into Login page

* add onLoginSuccess callback prop to intercept successful login and pass email/redirectUrl to parent for MFA handoff

* replace MFA_PATH redirect

* store tokens immediately after OAuth callback and navigate directly to return path

* change "Disabled" to "Not Available"

* replace hardcoded Link to backup code route

* fix digit array initialisation, add paste support, and add keyboard navigation

* fix authenticator name field above code input, display backup codes in a grid layout, animate copy button icon transition

* fix OTP input

* simplify layout by removing unused components

* replace PasswordIcon/CheckIcon with IDP logo image

* add top margin

* add LoginMfaFlow component within the Login page

* remove refresh button