### PR TITLE
triple the limit for rate limiting

### DIFF
--- a/backend/internal/middleware/rate_limit_mw.go
+++ b/backend/internal/middleware/rate_limit_mw.go
@@ -39,7 +39,7 @@ func (rl *rateLimiter) getLimiter(ip string) *rate.Limiter {
 	return limiter
 }
 
-var strictLimiter = newRateLimiter(rate.Every(12*time.Second), 5)
+var strictLimiter = newRateLimiter(rate.Every(12*time.Second), 15)
 
 // RateLimitMiddleware applies a strict rate limit for sensitive endpoints.
 func RateLimitMiddleware() gin.HandlerFunc {
@@ -49,7 +49,7 @@ func RateLimitMiddleware() gin.HandlerFunc {
 
 		if !limiter.Allow() {
 			c.AbortWithStatusJSON(http.StatusTooManyRequests, dto.ErrorResponse{
-				Error: "too_many_requests",
+				Error: "request limit exceeded",
 			})
 			return
 		}


### PR DESCRIPTION
This pull request updates the rate limiting logic for sensitive endpoints in the backend middleware. The main changes include increasing the burst limit for the strict rate limiter and improving the clarity of the error message returned when the rate limit is exceeded.

Rate limiting adjustments:

* Increased the burst size for the `strictLimiter` from 5 to 15, allowing more requests in a short period before rate limiting kicks in.

Error handling improvements:

* Updated the error message from `"too_many_requests"` to a more descriptive `"request limit exceeded"` when the rate limit is hit.