### PR TITLE
Filter registration config dynamically by admin allowed clients

### DIFF
--- a/backend/internal/api/v1/registration_handler.go
+++ b/backend/internal/api/v1/registration_handler.go
@@ -56,7 +56,17 @@ func (h *RegistrationHandler) GetRegistrationConfig(c *gin.Context) {
 		page = 1
 	}
 
-	config, err := h.Service.GetRegistrationConfig(c.Request.Context(), limit, page)
+	permissions := c.GetStringSlice("permissions")
+	userIDStr := c.GetString("user_id")
+	userID, _ := uuid.Parse(userIDStr)
+
+	config, err := h.Service.GetRegistrationConfig(
+		c.Request.Context(),
+		permissions,
+		userID,
+		limit,
+		page,
+	)
 	if err != nil {
 		log.Printf("[GetRegistrationConfig] %v", err)
 		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{

--- a/backend/internal/repository/registration_repository.go
+++ b/backend/internal/repository/registration_repository.go
@@ -27,6 +27,9 @@ type RegistrationRepository interface {
 	CreateAccountType(ctx context.Context, name string) (int, error)
 	UpdateAccountType(ctx context.Context, id int, name string) error
 	DeleteAccountType(ctx context.Context, id int) error
+	GetScopedRegistrationConfig(ctx context.Context, userID []byte,
+		limit, offset int) ([]AccountTypeClientRow, error)
+	CountScopedAccountTypes(ctx context.Context, userID []byte) (int, error)
 }
 
 type regRepo struct {
@@ -169,4 +172,51 @@ func (r *regRepo) DeleteAccountType(ctx context.Context, id int) error {
 	}
 
 	return tx.Commit()
+}
+
+func (r *regRepo) GetScopedRegistrationConfig(ctx context.Context,
+	userID []byte, limit, offset int) ([]AccountTypeClientRow, error) {
+	query := `
+		SELECT account_type_id, account_type_name, client_id, client_name
+		FROM (
+			SELECT 
+				at.id AS account_type_id,
+				at.name AS account_type_name,
+				cl.id AS client_id,
+				COALESCE(cl.client_name, '') AS client_name,
+				ROW_NUMBER() OVER (PARTITION BY at.id 
+					ORDER BY cl.client_name) as row_num
+			FROM (
+				SELECT DISTINCT at2.* FROM account_types at2
+				JOIN preapproved_clients pc2 ON at2.id = pc2.account_type_id
+				JOIN admin_allowed_clients aac2 ON pc2.client_id = aac2.client_id
+				WHERE aac2.user_id = ?
+				ORDER BY at2.id
+				LIMIT ? OFFSET ?
+			) at
+			LEFT JOIN preapproved_clients pc ON at.id = pc.account_type_id
+			LEFT JOIN clients cl ON pc.client_id = cl.id
+			JOIN admin_allowed_clients aac ON cl.id = aac.client_id
+			WHERE aac.user_id = ? AND cl.deleted_at IS NULL
+		) t
+		WHERE row_num <= 5
+		ORDER BY account_type_id;
+	`
+	var rows []AccountTypeClientRow
+	err := r.db.SelectContext(ctx, &rows, query, userID, limit, offset, userID)
+	return rows, err
+}
+
+func (r *regRepo) CountScopedAccountTypes(ctx context.Context,
+	userID []byte) (int, error) {
+	var count int
+	query := `
+		SELECT COUNT(DISTINCT at.id)
+		FROM account_types at
+		JOIN preapproved_clients pc ON at.id = pc.account_type_id
+		JOIN admin_allowed_clients aac ON pc.client_id = aac.client_id
+		WHERE aac.user_id = ?
+	`
+	err := r.db.GetContext(ctx, &count, query, userID)
+	return count, err
 }

--- a/backend/internal/service/registration_service.go
+++ b/backend/internal/service/registration_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 	"time"
 
 	"github.com/Iskolutions-Capstone-Dev-Team/Identity-Provider/internal/dto"
@@ -14,8 +15,9 @@ import (
 )
 
 type RegistrationService interface {
-	GetRegistrationConfig(ctx context.Context,
-		limit, page int) (*dto.RegistrationConfigResponse, error)
+	GetRegistrationConfig(ctx context.Context, permissions []string,
+		userID uuid.UUID, limit,
+		page int) (*dto.RegistrationConfigResponse, error)
 	GetClientsByAccountTypeID(ctx context.Context,
 		id int) (*dto.AccountTypeConfigResponse, error)
 	CreateAccountType(ctx context.Context,
@@ -52,16 +54,35 @@ func NewRegistrationService(
 }
 
 func (s *regService) GetRegistrationConfig(ctx context.Context,
-	limit, page int) (*dto.RegistrationConfigResponse, error) {
-	total, err := s.repo.CountAccountTypes(ctx)
-	if err != nil {
-		return nil, err
-	}
+	permissions []string, userID uuid.UUID, limit,
+	page int) (*dto.RegistrationConfigResponse, error) {
+	var total int
+	var rows []repository.AccountTypeClientRow
+	var err error
 
-	offset := (page - 1) * limit
-	rows, err := s.repo.GetRegistrationConfig(ctx, limit, offset)
-	if err != nil {
-		return nil, err
+	if slices.Contains(permissions, "View all appclients") {
+		total, err = s.repo.CountAccountTypes(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		offset := (page - 1) * limit
+		rows, err = s.repo.GetRegistrationConfig(ctx, limit, offset)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		total, err = s.repo.CountScopedAccountTypes(ctx, userID[:])
+		if err != nil {
+			return nil, err
+		}
+
+		offset := (page - 1) * limit
+		rows, err = s.repo.GetScopedRegistrationConfig(ctx, userID[:],
+			limit, offset)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	configMap := make(map[string][]dto.PreapprovedClientResponse)
@@ -71,12 +92,14 @@ func (s *regService) GetRegistrationConfig(ctx context.Context,
 	for _, row := range rows {
 		if _, ok := configMap[row.AccountTypeName]; !ok {
 			order = append(order, row.AccountTypeName)
-			configMap[row.AccountTypeName] = []dto.PreapprovedClientResponse{}
+			configMap[row.AccountTypeName] =
+				[]dto.PreapprovedClientResponse{}
 			idMap[row.AccountTypeName] = row.AccountTypeID
 		}
 		if len(row.ClientID) > 0 {
 			id, _ := uuid.FromBytes(row.ClientID)
-			configMap[row.AccountTypeName] = append(configMap[row.AccountTypeName],
+			configMap[row.AccountTypeName] = append(
+				configMap[row.AccountTypeName],
 				dto.PreapprovedClientResponse{
 					ID:   id,
 					Name: row.ClientName,
@@ -97,6 +120,9 @@ func (s *regService) GetRegistrationConfig(ctx context.Context,
 	resp.TotalCount = total
 	resp.CurrentPage = page
 	resp.LastPage = (total + limit - 1) / limit
+	if resp.LastPage == 0 {
+		resp.LastPage = 1
+	}
 
 	return &resp, nil
 }

--- a/backend/tests/handler/registration_handler_test.go
+++ b/backend/tests/handler/registration_handler_test.go
@@ -69,3 +69,73 @@ func TestCheckInvitationHandler(t *testing.T) {
 		t.Errorf("expected message 'invitation code is valid', got '%s'", resp.Message)
 	}
 }
+
+/**
+ * TestGetRegistrationConfigHandler verifies the GetRegistrationConfig endpoint.
+ */
+func TestGetRegistrationConfigHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("returns_unauthorized_when_permission_missing", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockRegService := mocks.NewMockRegistrationService(ctrl)
+		mockLogService := mocks.NewMockLogService(ctrl)
+
+		handler := &v1.RegistrationHandler{
+			Service:    mockRegService,
+			LogService: mockLogService,
+		}
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest("GET", "/admin/registration/config", nil)
+
+		handler.GetRegistrationConfig(c)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("expected status 401, got %d", w.Code)
+		}
+	})
+
+	t.Run("success_with_view_all", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockRegService := mocks.NewMockRegistrationService(ctrl)
+		mockLogService := mocks.NewMockLogService(ctrl)
+
+		handler := &v1.RegistrationHandler{
+			Service:    mockRegService,
+			LogService: mockLogService,
+		}
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest("GET", "/admin/registration/config", nil)
+
+		c.Set("permissions", []string{
+			"View Registration Config",
+			"View all appclients",
+		})
+		c.Set("user_id", "00000000-0000-0000-0000-000000000001")
+
+		mockRegService.EXPECT().GetRegistrationConfig(
+			gomock.Any(),
+			[]string{
+				"View Registration Config",
+				"View all appclients",
+			},
+			gomock.Any(),
+			10,
+			1,
+		).Return(&dto.RegistrationConfigResponse{}, nil)
+
+		handler.GetRegistrationConfig(c)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", w.Code)
+		}
+	})
+}

--- a/backend/tests/mocks/registration_repository_mock.go
+++ b/backend/tests/mocks/registration_repository_mock.go
@@ -158,3 +158,60 @@ func (mr *MockRegistrationRepositoryMockRecorder) UpdateAccountType(ctx, id, nam
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAccountType", reflect.TypeOf((*MockRegistrationRepository)(nil).UpdateAccountType), ctx, id, name)
 }
+
+// CountScopedAccountTypes mocks base method.
+func (m *MockRegistrationRepository) CountScopedAccountTypes(
+	ctx context.Context, userID []byte,
+) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountScopedAccountTypes", ctx, userID)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountScopedAccountTypes indicates an expected call of
+// CountScopedAccountTypes.
+func (mr *MockRegistrationRepositoryMockRecorder) CountScopedAccountTypes(
+	ctx, userID any,
+) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"CountScopedAccountTypes",
+		reflect.TypeOf((*MockRegistrationRepository)(nil).
+			CountScopedAccountTypes),
+		ctx,
+		userID,
+	)
+}
+
+// GetScopedRegistrationConfig mocks base method.
+func (m *MockRegistrationRepository) GetScopedRegistrationConfig(
+	ctx context.Context, userID []byte, limit, offset int,
+) ([]repository.AccountTypeClientRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetScopedRegistrationConfig", ctx, userID,
+		limit, offset)
+	ret0, _ := ret[0].([]repository.AccountTypeClientRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetScopedRegistrationConfig indicates an expected call of
+// GetScopedRegistrationConfig.
+func (mr *MockRegistrationRepositoryMockRecorder) GetScopedRegistrationConfig(
+	ctx, userID, limit, offset any,
+) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetScopedRegistrationConfig",
+		reflect.TypeOf((*MockRegistrationRepository)(nil).
+			GetScopedRegistrationConfig),
+		ctx,
+		userID,
+		limit,
+		offset,
+	)
+}

--- a/backend/tests/mocks/registration_service_mock.go
+++ b/backend/tests/mocks/registration_service_mock.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	dto "github.com/Iskolutions-Capstone-Dev-Team/Identity-Provider/internal/dto"
+	uuid "github.com/google/uuid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -114,18 +115,32 @@ func (mr *MockRegistrationServiceMockRecorder) GetClientsByAccountTypeID(ctx, id
 }
 
 // GetRegistrationConfig mocks base method.
-func (m *MockRegistrationService) GetRegistrationConfig(ctx context.Context, limit, page int) (*dto.RegistrationConfigResponse, error) {
+func (m *MockRegistrationService) GetRegistrationConfig(
+	ctx context.Context, permissions []string, userID uuid.UUID, limit, page int,
+) (*dto.RegistrationConfigResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRegistrationConfig", ctx, limit, page)
+	ret := m.ctrl.Call(m, "GetRegistrationConfig", ctx, permissions, userID,
+		limit, page)
 	ret0, _ := ret[0].(*dto.RegistrationConfigResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRegistrationConfig indicates an expected call of GetRegistrationConfig.
-func (mr *MockRegistrationServiceMockRecorder) GetRegistrationConfig(ctx, limit, page any) *gomock.Call {
+func (mr *MockRegistrationServiceMockRecorder) GetRegistrationConfig(
+	ctx, permissions, userID, limit, page any,
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegistrationConfig", reflect.TypeOf((*MockRegistrationService)(nil).GetRegistrationConfig), ctx, limit, page)
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetRegistrationConfig",
+		reflect.TypeOf((*MockRegistrationService)(nil).GetRegistrationConfig),
+		ctx,
+		permissions,
+		userID,
+		limit,
+		page,
+	)
 }
 
 // SyncUsersByAccountType mocks base method.

--- a/backend/tests/service/registration_service_test.go
+++ b/backend/tests/service/registration_service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Iskolutions-Capstone-Dev-Team/Identity-Provider/internal/repository"
 	"github.com/Iskolutions-Capstone-Dev-Team/Identity-Provider/internal/service"
 	"github.com/Iskolutions-Capstone-Dev-Team/Identity-Provider/tests/mocks"
+	"github.com/google/uuid"
 	"go.uber.org/mock/gomock"
 )
 
@@ -71,16 +72,31 @@ func TestGetRegistrationConfig(t *testing.T) {
 	offset := 0
 
 	rows := []repository.AccountTypeClientRow{
-		{AccountTypeID: 1, AccountTypeName: "Type A", ClientID: []byte{1}, ClientName: "Client 1"},
-		{AccountTypeID: 2, AccountTypeName: "Type B", ClientID: []byte{2}, ClientName: "Client 2"},
+		{
+			AccountTypeID:   1,
+			AccountTypeName: "Type A",
+			ClientID:        []byte{1},
+			ClientName:      "Client 1",
+		},
+		{
+			AccountTypeID:   2,
+			AccountTypeName: "Type B",
+			ClientID:        []byte{2},
+			ClientName:      "Client 2",
+		},
 	}
 
 	// 1. Setup mock expectations
 	mockRegRepo.EXPECT().CountAccountTypes(ctx).Return(5, nil)
-	mockRegRepo.EXPECT().GetRegistrationConfig(ctx, limit, offset).Return(rows, nil)
+	mockRegRepo.EXPECT().GetRegistrationConfig(ctx, limit, offset).
+		Return(rows, nil)
 
 	// 2. Execute
-	resp, err := regService.GetRegistrationConfig(ctx, limit, page)
+	permissions := []string{"View all appclients"}
+	userID := uuid.New()
+	resp, err := regService.GetRegistrationConfig(
+		ctx, permissions, userID, limit, page,
+	)
 
 	// 3. Verify
 	if err != nil {
@@ -101,5 +117,60 @@ func TestGetRegistrationConfig(t *testing.T) {
 
 	if len(resp.AccountTypes) != 2 {
 		t.Errorf("expected 2 account types, got %d", len(resp.AccountTypes))
+	}
+}
+
+/**
+ * TestGetRegistrationConfig_Scoped verifies the scoped filtering logic.
+ */
+func TestGetRegistrationConfig_Scoped(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRegRepo := mocks.NewMockRegistrationRepository(ctrl)
+	mockInvRepo := mocks.NewMockInvitationRepository(ctrl)
+	mockUserRepo := mocks.NewMockUserRepository(ctrl)
+	mockCauRepo := mocks.NewMockClientAllowedUserRepository(ctrl)
+
+	regService := service.NewRegistrationService(
+		mockRegRepo, mockInvRepo, mockUserRepo, mockCauRepo)
+
+	ctx := context.Background()
+	limit, page := 2, 1
+	offset := 0
+	userID := uuid.New()
+
+	rows := []repository.AccountTypeClientRow{
+		{
+			AccountTypeID:   1,
+			AccountTypeName: "Type A",
+			ClientID:        []byte{1},
+			ClientName:      "Client 1",
+		},
+	}
+
+	// 1. Setup mock expectations
+	mockRegRepo.EXPECT().CountScopedAccountTypes(ctx, userID[:]).
+		Return(1, nil)
+	mockRegRepo.EXPECT().GetScopedRegistrationConfig(ctx, userID[:],
+		limit, offset).Return(rows, nil)
+
+	// 2. Execute
+	permissions := []string{"View connected appclients"}
+	resp, err := regService.GetRegistrationConfig(
+		ctx, permissions, userID, limit, page,
+	)
+
+	// 3. Verify
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if resp.TotalCount != 1 {
+		t.Errorf("expected TotalCount 1, got %d", resp.TotalCount)
+	}
+
+	if len(resp.AccountTypes) != 1 {
+		t.Errorf("expected 1 account types, got %d", len(resp.AccountTypes))
 	}
 }


### PR DESCRIPTION
This pull request refactors the registration configuration endpoint to support permission-based scoping, allowing users with different permissions to see either all registration configs or only those they are allowed to access. It introduces new repository methods, updates the service and handler logic, and adds comprehensive tests for both permission scenarios.

**Permission-based registration config retrieval:**

* Updated `RegistrationService.GetRegistrationConfig` and handler to accept `permissions` and `userID`, returning all or scoped registration configs based on the presence of the "View all appclients" permission (`backend/internal/service/registration_service.go`, `backend/internal/api/v1/registration_handler.go`). [[1]](diffhunk://#diff-e5fcf6a9d9707af32c5d720398fc0c6dfe28352da151ab084bc9f7f1aa4de560L17-R20) [[2]](diffhunk://#diff-e5fcf6a9d9707af32c5d720398fc0c6dfe28352da151ab084bc9f7f1aa4de560L55-R86) [[3]](diffhunk://#diff-f56700eda79fde4d35cb9704c2987c278f78a6548e7bd2720bc52070c85f0fb1L59-R69)

**Repository enhancements:**

* Added `GetScopedRegistrationConfig` and `CountScopedAccountTypes` to `RegistrationRepository` to support permission-scoped queries, and implemented these methods (`backend/internal/repository/registration_repository.go`). [[1]](diffhunk://#diff-18033ec3a5a5f2a27643f28bbd3e68715820901c7a9a622856804e6a2ac9e641R30-R32) [[2]](diffhunk://#diff-18033ec3a5a5f2a27643f28bbd3e68715820901c7a9a622856804e6a2ac9e641R176-R222)

**Testing improvements:**

* Added and updated unit tests for both service and handler to verify correct behavior with and without the "View all appclients" permission, including new tests for scoped results (`backend/tests/service/registration_service_test.go`, `backend/tests/handler/registration_handler_test.go`). [[1]](diffhunk://#diff-6dd8bb0d5a37158b330c0f125d3f7577addc34d22844ae973f313e108461721bL74-R99) [[2]](diffhunk://#diff-6dd8bb0d5a37158b330c0f125d3f7577addc34d22844ae973f313e108461721bR122-R176) [[3]](diffhunk://#diff-1b2066468041ebee1b66e84c66ec4dc1e3afb046bc611489e911924f1fa0ab02R72-R141)

**Mocks and test utilities:**

* Updated service and repository mocks to include new methods and signatures, ensuring tests reflect the new permission-based logic (`backend/tests/mocks/registration_service_mock.go`, `backend/tests/mocks/registration_repository_mock.go`). [[1]](diffhunk://#diff-3d89664bc68b120c2925c36a648589a3ef1ca42939dc3f1ed7d8eca3384c9136L117-R143) [[2]](diffhunk://#diff-b84411c54989736ba0d9a67e0fb6880ec0ce0385c1d3d6b1a35eb629ddf1d9f1R161-R217)

**Minor improvements:**

* Ensured that `LastPage` in the registration config response is always at least 1 (`backend/internal/service/registration_service.go`).