### PR TITLE
Update User DTO and response building with portal link

### DIFF
--- a/backend/internal/api/v1/user_handler.go
+++ b/backend/internal/api/v1/user_handler.go
@@ -1304,6 +1304,7 @@ func (h *UserHandler) GetUserDetailedAccess(c *gin.Context) {
 			Description:   cl.Description,
 			ImageLocation: cl.ImageLocation,
 			BaseURL:       cl.BaseURL,
+			OnePortalLink: cl.OnePortalLink,
 		})
 	}
 

--- a/backend/internal/dto/user_dto.go
+++ b/backend/internal/dto/user_dto.go
@@ -78,6 +78,7 @@ type ClientDetailedAccessResponse struct {
 	Description   string `json:"description"`
 	ImageLocation string `json:"image_location"`
 	BaseURL       string `json:"base_url"`
+	OnePortalLink string `json:"one_portal_link"`
 }
 
 // UserResponse provides a safe view of user data, hiding the password hash.


### PR DESCRIPTION
This pull request adds support for including the `OnePortalLink` field in user access details. The main changes ensure that the new field is available in both the API response and the data transfer object.

Enhancements to user access details:

* Added the `OnePortalLink` field to the `ClientDetailedAccessResponse` struct in `user_dto.go` to support returning the new information.
* Updated the `GetUserDetailedAccess` handler in `user_handler.go` to populate the `OnePortalLink` field in API responses.