### PR TITLE
Enhance PasskeyService with dynamic platform availability support

### DIFF
--- a/backend/internal/api/v1/passkey_handler.go
+++ b/backend/internal/api/v1/passkey_handler.go
@@ -28,8 +28,13 @@ func (h *PasskeyHandler) BeginRegistration(c *gin.Context) {
 		return
 	}
 
+	platformAvailable := false
+	if req.PlatformAvailable != nil {
+		platformAvailable = *req.PlatformAvailable
+	}
+
 	challenge, err := h.PasskeyService.BeginRegistration(
-		c.Request.Context(), req.Email,
+		c.Request.Context(), req.Email, platformAvailable,
 	)
 	if err != nil {
 		log.Printf("[BeginRegistration] Service: %v", err)
@@ -85,8 +90,13 @@ func (h *PasskeyHandler) BeginVerification(c *gin.Context) {
 		return
 	}
 
+	platformAvailable := false
+	if req.PlatformAvailable != nil {
+		platformAvailable = *req.PlatformAvailable
+	}
+
 	challenge, err := h.PasskeyService.BeginVerification(
-		c.Request.Context(), req.Email,
+		c.Request.Context(), req.Email, platformAvailable,
 	)
 	if err != nil {
 		log.Printf("[BeginVerification] Service: %v", err)

--- a/backend/internal/dto/mfa_dto.go
+++ b/backend/internal/dto/mfa_dto.go
@@ -43,5 +43,6 @@ type MFAAuthenticatorResponse struct {
 // authentication ceremony. The backend uses the email to load the
 // user and build the WebAuthn challenge.
 type PasskeyBeginRequest struct {
-	Email string `json:"email" binding:"required"`
+	Email             string `json:"email" binding:"required"`
+	PlatformAvailable *bool  `json:"platform_available"`
 }

--- a/backend/internal/initializers/services.go
+++ b/backend/internal/initializers/services.go
@@ -27,7 +27,11 @@ func InitializeServices(db *sqlx.DB) service.ServiceContainer {
 		cauRepo,
 	)
 
-	passkeySvc, err := service.NewPasskeyService(passkeyRepo, userSvc)
+	passkeySvc, err := service.NewPasskeyService(
+		passkeyRepo,
+		userSvc,
+		clientRepo,
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/backend/internal/repository/client_repository.go
+++ b/backend/internal/repository/client_repository.go
@@ -274,7 +274,17 @@ func (r *clientRepository) GetClientAllowedRoles(ctx context.Context,
 func (r *clientRepository) ListClientBaseURLS(ctx context.Context,
 ) ([]string, error) {
 	var baseURLS []string
-	query := `SELECT base_url FROM clients WHERE deleted_at IS NULL`
+	query := `
+		SELECT base_url FROM clients 
+		WHERE deleted_at IS NULL 
+		  AND base_url IS NOT NULL 
+		  AND base_url != ''
+		UNION
+		SELECT one_portal_link FROM clients 
+		WHERE deleted_at IS NULL 
+		  AND one_portal_link IS NOT NULL 
+		  AND one_portal_link != ''
+	`
 	err := r.db.SelectContext(ctx, &baseURLS, query)
 	if err != nil {
 		return nil, err

--- a/backend/internal/service/passkey_service.go
+++ b/backend/internal/service/passkey_service.go
@@ -70,10 +70,12 @@ func rpidFromURL(rawURL string) string {
 }
 
 // NewPasskeyService constructs a PasskeyService using CLIENT_BASE_URL
-// as both the WebAuthn origin and the source of the RPID.
+// as both the WebAuthn origin and the source of the RPID, along with
+// allowed client origins from the database.
 func NewPasskeyService(
 	pr repository.PasskeyRepository,
 	us UserService,
+	cr repository.ClientRepository,
 ) (PasskeyService, error) {
 	origin := os.Getenv("CLIENT_BASE_URL")
 	if origin == "" {
@@ -83,14 +85,38 @@ func NewPasskeyService(
 	}
 
 	rpid := rpidFromURL(origin)
-	// Strip trailing slash from origin for strict matching.
 	origin = strings.TrimRight(origin, "/")
+
+	originsMap := make(map[string]bool)
+	originsMap[origin] = true
+
+	// Query other allowed client origins from DB
+	dbURLS, err := cr.ListClientBaseURLS(context.Background())
+	if err == nil {
+		for _, u := range dbURLS {
+			parsed, err := url.Parse(u)
+			if err != nil || parsed.Host == "" {
+				continue
+			}
+			scheme := parsed.Scheme
+			if scheme == "" {
+				scheme = "http"
+			}
+			orig := fmt.Sprintf("%s://%s", scheme, parsed.Host)
+			originsMap[orig] = true
+		}
+	}
+
+	var origins []string
+	for o := range originsMap {
+		origins = append(origins, o)
+	}
 
 	requireRK := true
 	wa, err := webauthn.New(&webauthn.Config{
 		RPDisplayName: "Identity Provider",
 		RPID:          rpid,
-		RPOrigins:     []string{origin},
+		RPOrigins:     origins,
 		AuthenticatorSelection: protocol.AuthenticatorSelection{
 			RequireResidentKey: &requireRK,
 			ResidentKey:        protocol.ResidentKeyRequirementRequired,

--- a/backend/internal/service/passkey_service.go
+++ b/backend/internal/service/passkey_service.go
@@ -34,16 +34,15 @@ func (u *PasskeyUser) WebAuthnCredentials() []webauthn.Credential {
 	return u.credentials
 }
 
-// PasskeyService manages WebAuthn registration and verification.
 type PasskeyService interface {
 	BeginRegistration(
-		ctx context.Context, email string,
+		ctx context.Context, email string, platformAvailable bool,
 	) ([]byte, error)
 	FinishRegistration(
 		ctx context.Context, email string, r *http.Request,
 	) error
 	BeginVerification(
-		ctx context.Context, email string,
+		ctx context.Context, email string, platformAvailable bool,
 	) ([]byte, error)
 	FinishVerification(
 		ctx context.Context, email string, r *http.Request,
@@ -194,14 +193,27 @@ func (s *passkeyService) buildPasskeyUser(
 
 // BeginRegistration generates a WebAuthn registration challenge.
 func (s *passkeyService) BeginRegistration(
-	ctx context.Context, email string,
+	ctx context.Context, email string, platformAvailable bool,
 ) ([]byte, error) {
 	pu, err := s.buildPasskeyUser(ctx, email)
 	if err != nil {
 		return nil, err
 	}
 
-	creation, session, err := s.wa.BeginRegistration(pu)
+	var opts []webauthn.RegistrationOption
+	if platformAvailable {
+		requireRK := true
+		opts = append(opts, webauthn.WithAuthenticatorSelection(
+			protocol.AuthenticatorSelection{
+				AuthenticatorAttachment: protocol.Platform,
+				RequireResidentKey:      &requireRK,
+				ResidentKey:             protocol.ResidentKeyRequirementRequired,
+				UserVerification:        protocol.VerificationPreferred,
+			},
+		))
+	}
+
+	creation, session, err := s.wa.BeginRegistration(pu, opts...)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"[PasskeyService] Begin Registration: %w", err,
@@ -276,7 +288,7 @@ func (s *passkeyService) FinishRegistration(
 
 // BeginVerification generates a WebAuthn authentication challenge.
 func (s *passkeyService) BeginVerification(
-	ctx context.Context, email string,
+	ctx context.Context, email string, platformAvailable bool,
 ) ([]byte, error) {
 	pu, err := s.buildPasskeyUser(ctx, email)
 	if err != nil {

--- a/backend/tests/mocks/passkey_service_mock.go
+++ b/backend/tests/mocks/passkey_service_mock.go
@@ -45,10 +45,10 @@ func (m *MockPasskeyService) EXPECT() *MockPasskeyServiceMockRecorder {
 
 // BeginRegistration mocks base method.
 func (m *MockPasskeyService) BeginRegistration(
-	ctx context.Context, email string,
+	ctx context.Context, email string, platformAvailable bool,
 ) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BeginRegistration", ctx, email)
+	ret := m.ctrl.Call(m, "BeginRegistration", ctx, email, platformAvailable)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -56,13 +56,13 @@ func (m *MockPasskeyService) BeginRegistration(
 
 // BeginRegistration indicates an expected call of BeginRegistration.
 func (mr *MockPasskeyServiceMockRecorder) BeginRegistration(
-	ctx, email any,
+	ctx, email, platformAvailable any,
 ) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(
 		mr.mock, "BeginRegistration",
 		reflect.TypeOf((*MockPasskeyService)(nil).BeginRegistration),
-		ctx, email,
+		ctx, email, platformAvailable,
 	)
 }
 
@@ -90,10 +90,10 @@ func (mr *MockPasskeyServiceMockRecorder) FinishRegistration(
 
 // BeginVerification mocks base method.
 func (m *MockPasskeyService) BeginVerification(
-	ctx context.Context, email string,
+	ctx context.Context, email string, platformAvailable bool,
 ) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BeginVerification", ctx, email)
+	ret := m.ctrl.Call(m, "BeginVerification", ctx, email, platformAvailable)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -101,13 +101,13 @@ func (m *MockPasskeyService) BeginVerification(
 
 // BeginVerification indicates an expected call of BeginVerification.
 func (mr *MockPasskeyServiceMockRecorder) BeginVerification(
-	ctx, email any,
+	ctx, email, platformAvailable any,
 ) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(
 		mr.mock, "BeginVerification",
 		reflect.TypeOf((*MockPasskeyService)(nil).BeginVerification),
-		ctx, email,
+		ctx, email, platformAvailable,
 	)
 }
 

--- a/frontend/src/auth/components/LoginMfaFlow.jsx
+++ b/frontend/src/auth/components/LoginMfaFlow.jsx
@@ -176,7 +176,18 @@ export default function LoginMfaFlow({ callbackRedirectUrl = "", initialEmail = 
   };
 
   const registerPasskey = async () => {
-    const options = await mfaService.beginPasskeyRegistration(email);
+    let platformAvailable = false;
+    if (window.PublicKeyCredential &&
+        typeof window.PublicKeyCredential
+          .isUserVerifyingPlatformAuthenticatorAvailable === "function") {
+      platformAvailable = await window.PublicKeyCredential
+        .isUserVerifyingPlatformAuthenticatorAvailable();
+    }
+
+    const options = await mfaService.beginPasskeyRegistration(
+      email,
+      platformAvailable,
+    );
     const credential = await createPasskeyCredential(options);
 
     await mfaService.finishPasskeyRegistration(email, credential);
@@ -184,7 +195,18 @@ export default function LoginMfaFlow({ callbackRedirectUrl = "", initialEmail = 
   };
 
   const verifyPasskey = async () => {
-    const options = await mfaService.beginPasskeyVerification(email);
+    let platformAvailable = false;
+    if (window.PublicKeyCredential &&
+        typeof window.PublicKeyCredential
+          .isUserVerifyingPlatformAuthenticatorAvailable === "function") {
+      platformAvailable = await window.PublicKeyCredential
+        .isUserVerifyingPlatformAuthenticatorAvailable();
+    }
+
+    const options = await mfaService.beginPasskeyVerification(
+      email,
+      platformAvailable,
+    );
     const credential = await getPasskeyCredential(options);
 
     await mfaService.finishPasskeyVerification(email, credential);

--- a/frontend/src/auth/pages/Mfa.jsx
+++ b/frontend/src/auth/pages/Mfa.jsx
@@ -168,7 +168,18 @@ export default function Mfa() {
   };
 
   const registerPasskey = async () => {
-    const options = await mfaService.beginPasskeyRegistration(email);
+    let platformAvailable = false;
+    if (window.PublicKeyCredential &&
+        typeof window.PublicKeyCredential
+          .isUserVerifyingPlatformAuthenticatorAvailable === "function") {
+      platformAvailable = await window.PublicKeyCredential
+        .isUserVerifyingPlatformAuthenticatorAvailable();
+    }
+
+    const options = await mfaService.beginPasskeyRegistration(
+      email,
+      platformAvailable,
+    );
     const credential = await createPasskeyCredential(options);
 
     await mfaService.finishPasskeyRegistration(email, credential);
@@ -176,7 +187,18 @@ export default function Mfa() {
   };
 
   const verifyPasskey = async () => {
-    const options = await mfaService.beginPasskeyVerification(email);
+    let platformAvailable = false;
+    if (window.PublicKeyCredential &&
+        typeof window.PublicKeyCredential
+          .isUserVerifyingPlatformAuthenticatorAvailable === "function") {
+      platformAvailable = await window.PublicKeyCredential
+        .isUserVerifyingPlatformAuthenticatorAvailable();
+    }
+
+    const options = await mfaService.beginPasskeyVerification(
+      email,
+      platformAvailable,
+    );
     const credential = await getPasskeyCredential(options);
 
     await mfaService.finishPasskeyVerification(email, credential);

--- a/frontend/src/services/mfaService.js
+++ b/frontend/src/services/mfaService.js
@@ -120,10 +120,13 @@ export const mfaService = {
    * Passkey (WebAuthn) — Registration
    * Step 1: fetch the challenge from the server.
    */
-  async beginPasskeyRegistration(email) {
+  async beginPasskeyRegistration(email, platformAvailable) {
     const response = await axiosInstance.post(
       "/mfa/passkey/register/begin",
-      { email: getRequiredTextValue(email, "Email address") },
+      {
+        email: getRequiredTextValue(email, "Email address"),
+        platform_available: platformAvailable,
+      },
       {
         skipUnauthorizedRedirect: true,
       },
@@ -153,10 +156,13 @@ export const mfaService = {
    * Passkey (WebAuthn) — Authentication
    * Step 1: fetch the assertion challenge from the server.
    */
-  async beginPasskeyVerification(email) {
+  async beginPasskeyVerification(email, platformAvailable) {
     const response = await axiosInstance.post(
       "/mfa/passkey/verify/begin",
-      { email: getRequiredTextValue(email, "Email address") },
+      {
+        email: getRequiredTextValue(email, "Email address"),
+        platform_available: platformAvailable,
+      },
       {
         skipAuthHeader: true,
       },


### PR DESCRIPTION
This pull request enhances the passkey (WebAuthn) registration and authentication flow by allowing the frontend to detect and communicate platform authenticator availability to the backend. The backend uses this information to tailor WebAuthn challenges, and also now supports multiple allowed client origins for RPID/origin validation. The changes span both backend and frontend, updating interfaces, services, and mocks to support the new parameter and logic.

**Passkey/WebAuthn platform authenticator support:**

* The frontend (`LoginMfaFlow.jsx`, `Mfa.jsx`, `mfaService.js`) now detects if a platform authenticator is available using the WebAuthn API, and includes this information in requests to begin passkey registration and verification. [[1]](diffhunk://#diff-b5048d1465852aa1ba5ac783807e00cb84fca371aca6d3427d39d21ffdde97a2L179-R209) [[2]](diffhunk://#diff-5bd694ee7ee6034ac7fc66d6b36cb2d1c9ccb3b2364c6c2970ab567edb00aaa2L171-R201) [[3]](diffhunk://#diff-d7aa16ee3b85c375055b93dc3b039f369773e859dc9a96be3117c15d3d4467d3L123-R129) [[4]](diffhunk://#diff-d7aa16ee3b85c375055b93dc3b039f369773e859dc9a96be3117c15d3d4467d3L156-R165)
* The backend (`passkey_handler.go`, `mfa_dto.go`, `passkey_service.go`) receives the `platformAvailable` parameter, and if true, customizes the WebAuthn challenge to require a platform authenticator. [[1]](diffhunk://#diff-52cbbeb29adec54bcfb61870ee16eb69e757006dd694c9cfa6b226cda1c84876R31-R37) [[2]](diffhunk://#diff-52cbbeb29adec54bcfb61870ee16eb69e757006dd694c9cfa6b226cda1c84876R93-R99) [[3]](diffhunk://#diff-4512a5a45cc67d94f045f6a8c7a01c88cee682d1f8e0aaadde8868212fc78a27R47) [[4]](diffhunk://#diff-0710d421dd414593252b17264fbbc2f150724acacccd6c2a65e752c4691b0f51L171-R216) [[5]](diffhunk://#diff-0710d421dd414593252b17264fbbc2f150724acacccd6c2a65e752c4691b0f51L253-R291) [[6]](diffhunk://#diff-0710d421dd414593252b17264fbbc2f150724acacccd6c2a65e752c4691b0f51L37-R45)

**Multi-origin support for WebAuthn:**

* The backend's `NewPasskeyService` now queries all client origins from the database and configures WebAuthn to accept assertions from any of these origins, improving support for multiple frontends. [[1]](diffhunk://#diff-5faa4d2937b1fc3389f175a7a3e048033bffd58fdcb833e206ce741e0b1287c7L30-R34) [[2]](diffhunk://#diff-0710d421dd414593252b17264fbbc2f150724acacccd6c2a65e752c4691b0f51L73-R77) [[3]](diffhunk://#diff-7a07eb43ab83051a48ec7eb4503f4cd31dc46d7850b8d548ee5c8f9a19e8647eL277-R287) [[4]](diffhunk://#diff-0710d421dd414593252b17264fbbc2f150724acacccd6c2a65e752c4691b0f51L86-R118)

**Interface and test updates:**

* The `PasskeyService` interface and its mocks are updated to support the new `platformAvailable` parameter for both registration and verification, ensuring tests and dependency injection remain consistent. [[1]](diffhunk://#diff-0710d421dd414593252b17264fbbc2f150724acacccd6c2a65e752c4691b0f51L37-R45) [[2]](diffhunk://#diff-99120d844d86a32ab9c7c55c831848f9779a281e6aaeb82483e6743b19ab9411L48-R65) [[3]](diffhunk://#diff-99120d844d86a32ab9c7c55c831848f9779a281e6aaeb82483e6743b19ab9411L93-R110)